### PR TITLE
Add implicit execution context to Fs2Rabbit.apply

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/StreamLoop.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/StreamLoop.scala
@@ -34,10 +34,12 @@ import scala.concurrent.duration._
 object StreamLoop {
 
   def run[F[_]](program: () => Stream[F, Unit], retry: FiniteDuration = 5.seconds)(implicit F: Effect[F],
-                                                                                   ec: ExecutionContext): IO[Unit] =
-    F.runAsync(loop(program(), retry).compile.drain) {
-      case Right(_) => IO.unit
-      case Left(e)  => IO.raiseError(e) // Should be unreachable
+                                                                                   ec: ExecutionContext): F[Unit] =
+    F.liftIO {
+      F.runAsync(loop(program(), retry).compile.drain) {
+        case Right(_) => IO.unit
+        case Left(e)  => IO.raiseError(e) // Should be unreachable
+      }
     }
 
   private def loop[F[_]: Effect](program: Stream[F, Unit], retry: FiniteDuration)(

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
@@ -24,10 +24,10 @@ import scala.concurrent.ExecutionContext
 
 object IOAckerConsumer extends IOApp {
 
-  implicit val appS: ExecutionContext     = scala.concurrent.ExecutionContext.Implicits.global
-  implicit val interpreter: Fs2Rabbit[IO] = Fs2Rabbit[IO]
+  implicit val appS: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   override def start(args: List[String]): IO[Unit] =
-    StreamLoop.run(() => new AckerConsumerDemo[IO]().program)
-
+    Fs2Rabbit[IO].flatMap { implicit interpreter =>
+      StreamLoop.run(() => new AckerConsumerDemo[IO]().program)
+    }
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -26,10 +26,10 @@ import scala.concurrent.ExecutionContext
 
 object MonixAutoAckConsumer extends IOApp {
 
-  implicit val appS: ExecutionContext       = scala.concurrent.ExecutionContext.Implicits.global
-  implicit val interpreter: Fs2Rabbit[Task] = Fs2Rabbit[Task]
+  implicit val appS: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   override def start(args: List[String]): IO[Unit] =
-    StreamLoop.run(() => new AutoAckConsumerDemo[Task].program)
-
+    Fs2Rabbit[Task].flatMap { implicit interpreter =>
+      StreamLoop.run(() => new AutoAckConsumerDemo[Task].program)
+    }.toIO
 }


### PR DESCRIPTION
This PR adds the ability to specify the internal queue's execution context.

I've had a look around the code and there are a couple of places where `unsafeRunSync` is being called. Maybe we can get around it somehow, but not sure as of now :)

I changed the signature to return an `F[Fs2Rabbit[F]]` similar to what's being done in fs2 for mutable queues and the like. I think it's a good idea to be pure all the way. See the examples for the code change needed, it's not so bad :)