### PR TITLE
Harmonize execution contexts

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -38,7 +38,7 @@ object Fs2Rabbit {
       amqpClient <- F.delay(new AmqpClientStream[F](internalQ))
       config     <- F.delay(new Fs2RabbitConfigManager[F].config)
       connStream <- F.delay(new ConnectionStream[F](config))
-      fs2Rabbit  <- F.delay(new Fs2Rabbit[F](config, connStream, internalQ)(F, amqpClient))
+      fs2Rabbit  <- F.delay(new Fs2Rabbit[F](config, connStream, internalQ)(F, amqpClient, ec))
     } yield fs2Rabbit
 }
 // $COVERAGE-ON$
@@ -46,7 +46,8 @@ object Fs2Rabbit {
 class Fs2Rabbit[F[_]](config: F[Fs2RabbitConfig],
                       connectionStream: Connection[Stream[F, ?]],
                       internalQ: Queue[IO, Either[Throwable, AmqpEnvelope]])(implicit F: Effect[F],
-                                                                             amqpClient: AMQPClient[Stream[F, ?]]) {
+                                                                             amqpClient: AMQPClient[Stream[F, ?]],
+                                                                             EC: ExecutionContext) {
 
   private implicit val ackerConsumerProgram: AckerConsumerProgram[F] =
     new AckerConsumerProgram[F](internalQ, config)

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerConsumerProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerConsumerProgram.scala
@@ -25,9 +25,13 @@ import com.rabbitmq.client.Channel
 import fs2.async.mutable
 import fs2.{Pipe, Sink, Stream}
 
-class AckerConsumerProgram[F[_]](
-    internalQ: mutable.Queue[IO, Either[Throwable, AmqpEnvelope]],
-    config: F[Fs2RabbitConfig])(implicit F: Async[F], SE: StreamEval[F], AMQP: AMQPClient[Stream[F, ?]])
+import scala.concurrent.ExecutionContext
+
+class AckerConsumerProgram[F[_]](internalQ: mutable.Queue[IO, Either[Throwable, AmqpEnvelope]],
+                                 config: F[Fs2RabbitConfig])(implicit F: Async[F],
+                                                             SE: StreamEval[F],
+                                                             AMQP: AMQPClient[Stream[F, ?]],
+                                                             EC: ExecutionContext)
     extends AckerConsumer[Stream[F, ?], Sink[F, ?]] {
 
   private def resilientConsumer: Pipe[F, Either[Throwable, AmqpEnvelope], AmqpEnvelope] =

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -54,7 +54,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         ackerQ     <- fs2.async.boundedQueue[IO, AckResult](500)
         amqpClient <- IO(new AMQPClientInMemory(internalQ, ackerQ, config))
         connStream <- IO(new ConnectionStub)
-        fs2Rabbit  <- IO(new Fs2Rabbit[IO](config, connStream, internalQ)(Effect[IO], amqpClient))
+        fs2Rabbit  <- IO(new Fs2Rabbit[IO](config, connStream, internalQ)(Effect[IO], amqpClient, global))
       } yield fs2Rabbit
       interpreter.unsafeRunSync()
     }


### PR DESCRIPTION
Originally there were two internal execution contexts, this PR
makes sure a single configurable EC is running fs2-rabbit.