### PR TITLE
Configuring Travis CI to also build the microsite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_cache:
   - find $HOME/.sbt -name "*.lock" -delete
 
 script:
-  - sbt clean +coverage +test +coverageReport +coverageAggregate
+  - sbt buildFs2Rabbit
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -124,5 +124,5 @@ lazy val microsite = project.in(file("site"))
   .dependsOn(`fs2-rabbit`)
 
 // CI build
-addCommandAlias("buildFs2Rabbit", ";clean;+coverage;+test;+coverageReport;+coverageAggregate;makeMicrosite")
+addCommandAlias("buildFs2Rabbit", ";clean;+coverage;+test;+coverageReport;+coverageAggregate;tut")
 

--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ lazy val noPublish = Seq(
 )
 
 lazy val `fs2-rabbit-root` = project.in(file("."))
-  .aggregate(`fs2-rabbit`, `fs2-rabbit-examples`)
+  .aggregate(`fs2-rabbit`, `fs2-rabbit-examples`, microsite)
   .settings(noPublish)
 
 lazy val `fs2-rabbit` = project.in(file("core"))
@@ -122,3 +122,7 @@ lazy val microsite = project.in(file("site"))
     micrositeGithubToken := sys.env.get("GITHUB_TOKEN")
   )
   .dependsOn(`fs2-rabbit`)
+
+// CI build
+addCommandAlias("buildFs2Rabbit", ";clean;+coverage;+test;+coverageReport;+coverageAggregate;makeMicrosite")
+


### PR DESCRIPTION
Aggregating the microsite module to be part of the build. This way we can keep documentation updated since for every breaking change the documentation will not compile and will need to be fixed to get a successful build on Travis CI.