### PR TITLE
Fixing consumers bug related to shared internal queue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ val commonSettings = Seq(
     "-language:higherKinds"
   ),
   scalafmtOnCompile := true,
-  coverageExcludedPackages := "com\\.github\\.gvolpe\\.fs2rabbit\\.examples.*;com\\.github\\.gvolpe\\.fs2rabbit\\.typeclasses.*;com\\.github\\.gvolpe\\.fs2rabbit\\.instances.*;.*QueueName*;.*RoutingKey*;.*ExchangeName*;.*DeliveryTag*;.*AmqpClientStream*;.*ConnectionStream*;",
+  coverageExcludedPackages := "com\\.github\\.gvolpe\\.fs2rabbit\\.examples.*;com\\.github\\.gvolpe\\.fs2rabbit\\.typeclasses.*;com\\.github\\.gvolpe\\.fs2rabbit\\.instances.*;.*QueueName*;.*RoutingKey*;.*ExchangeName*;.*DeliveryTag*;.*AMQPClientStream*;.*ConnectionStream*;",
   publishTo := {
     val sonatype = "https://oss.sonatype.org/"
     if (isSnapshot.value)

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ organization in ThisBuild := "com.github.gvolpe"
 
 version in ThisBuild := "0.5"
 
-crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.4")
+crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.6")
 
 sonatypeProfileName := "com.github.gvolpe"
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
@@ -27,7 +27,7 @@ trait AMQPClient[F[_]] extends Binding[F] with Declaration[F] with Deletion[F] {
   def basicAck(channel: Channel, tag: DeliveryTag, multiple: Boolean): F[Unit]
   def basicNack(channel: Channel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit]
   def basicQos(channel: Channel, basicQos: BasicQos): F[Unit]
-  def basicConsume(channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Map[String, AnyRef]): F[String]
+  def basicConsume(channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Map[String, AnyRef])(internals: AMQPInternals): F[String]
   def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[String]): F[Unit]
 }
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPInternals.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPInternals.scala
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit.typeclasses
+package com.github.gvolpe.fs2rabbit.algebra
 
-import cats.effect.Sync
-import org.slf4j.LoggerFactory
+import cats.effect.IO
+import com.github.gvolpe.fs2rabbit.model.AmqpEnvelope
+import fs2.async.mutable
 
-trait Log[F[_]] {
-  def info(value: String): F[Unit]
-  def error(error: Throwable): F[Unit]
-}
-
-object Log {
-  private[fs2rabbit] val logger = LoggerFactory.getLogger(this.getClass)
-
-  implicit def syncLogInstance[F[_]](implicit F: Sync[F]): Log[F] =
-    new Log[F] {
-      override def error(error: Throwable): F[Unit] = F.delay(logger.error(error.getMessage, error))
-      override def info(value: String): F[Unit]     = F.delay(logger.info(value))
-    }
-}
+case class AMQPInternals(queue: mutable.Queue[IO, Either[Throwable, AmqpEnvelope]])

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStream.scala
@@ -29,7 +29,7 @@ import fs2.Stream
 class ConnectionStream[F[_]](config: Fs2RabbitConfig)(implicit F: Sync[F], L: Log[F], SE: StreamEval[F])
     extends Connection[Stream[F, ?]] {
 
-  private lazy val connFactory: F[ConnectionFactory] =
+  private[fs2rabbit] lazy val connFactory: F[ConnectionFactory] =
     F.delay {
       val factory = new ConnectionFactory()
       factory.setHost(config.host)
@@ -44,7 +44,7 @@ class ConnectionStream[F[_]](config: Fs2RabbitConfig)(implicit F: Sync[F], L: Lo
       factory
     }
 
-  private def acquireConnection: F[(RabbitMQConnection, AMQPChannel)] =
+  private[fs2rabbit] def acquireConnection: F[(RabbitMQConnection, AMQPChannel)] =
     for {
       factory <- connFactory
       conn    <- F.delay(factory.newConnection)

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -16,8 +16,7 @@
 
 package com.github.gvolpe.fs2rabbit.interpreter
 
-import cats.effect.{Effect, IO}
-import cats.syntax.all._
+import cats.effect.Effect
 import com.github.gvolpe.fs2rabbit.algebra.{AMQPClient, Connection}
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.config.declaration.DeclarationQueueConfig
@@ -32,12 +31,12 @@ import scala.concurrent.ExecutionContext
 // $COVERAGE-OFF$
 object Fs2Rabbit {
   def apply[F[_]](config: Fs2RabbitConfig)(implicit F: Effect[F], ec: ExecutionContext): F[Fs2Rabbit[F]] =
-    for {
-      amqpClient    <- F.delay(new AMQPClientStream[F])
-      connStream    <- F.delay(new ConnectionStream[F](config))
-      ackerConsumer = new AckerConsumerProgram[F](config, amqpClient)
-      fs2Rabbit     <- F.delay(new Fs2Rabbit[F](config, connStream, amqpClient, ackerConsumer)(F, ec))
-    } yield fs2Rabbit
+    F.pure {
+      val amqpClient    = new AMQPClientStream[F]
+      val connStream    = new ConnectionStream[F](config)
+      val ackerConsumer = new AckerConsumerProgram[F](config, amqpClient)
+      new Fs2Rabbit[F](config, connStream, amqpClient, ackerConsumer)
+    }
 }
 // $COVERAGE-ON$
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/ConsumingProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/ConsumingProgram.scala
@@ -23,7 +23,7 @@ import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.{Sink, Stream}
 
-class ConsumingProgram[F[_]: Async](implicit C: AckerConsumer[Stream[F, ?], Sink[F, ?]], SE: StreamEval[F])
+class ConsumingProgram[F[_]: Async](C: AckerConsumer[Stream[F, ?], Sink[F, ?]])(implicit SE: StreamEval[F])
     extends Consuming[Stream[F, ?], Sink[F, ?]] {
 
   override def createAckerConsumer(

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/PublishingProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/PublishingProgram.scala
@@ -23,7 +23,7 @@ import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.{Sink, Stream}
 
-class PublishingProgram[F[_]: Sync](implicit SE: StreamEval[F], AMQP: AMQPClient[Stream[F, ?]])
+class PublishingProgram[F[_]: Sync](AMQP: AMQPClient[Stream[F, ?]])(implicit SE: StreamEval[F])
     extends Publishing[Stream[F, ?], Sink[F, ?]] {
 
   override def createPublisher(channel: Channel,

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -59,10 +59,10 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         internalQ     <- fs2.async.boundedQueue[IO, Either[Throwable, AmqpEnvelope]](500)
         ackerQ        <- fs2.async.boundedQueue[IO, AckResult](500)
         internals     = AMQPInternals(internalQ)
-        amqpClient    <- IO(new AMQPClientInMemory(internals, ackerQ, config))
-        connStream    <- IO(new ConnectionStub)
+        amqpClient    = new AMQPClientInMemory(internals, ackerQ, config)
+        connStream    = new ConnectionStub
         ackerConsumer = new TestAckerConsumer(config, internals, amqpClient)
-        fs2Rabbit     <- IO(new Fs2Rabbit[IO](config, connStream, amqpClient, ackerConsumer))
+        fs2Rabbit     = new Fs2Rabbit[IO](config, connStream, amqpClient, ackerConsumer)
       } yield fs2Rabbit
       interpreter.unsafeRunSync()
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,10 +3,10 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val catsEffect = "0.10"
-    val fs2        = "0.10.3"
+    val catsEffect = "1.0.0-RC"
+    val fs2        = "0.10.4"
     val circe      = "0.9.2"
-    val amqpClient = "4.1.0"
+    val amqpClient = "4.6.0"
     val logback    = "1.1.3"
     val monix      = "3.0.0-RC1"
 


### PR DESCRIPTION
It closes #59 

In addition, dependencies have been updated to the latest versions and also update Scala to 2.12.6.

This might not be the greatest solution but it fixes this terrible bug and leaves us with a test coverage of 91.86%, not too bad. In the long term, I'd like to have a better solution that might involve a change in the design, suggestions welcome.