### PR TITLE
Compile time typesafe arguments based on existential types

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
@@ -16,6 +16,7 @@
 
 package com.github.gvolpe.fs2rabbit.algebra
 
+import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.config.declaration.DeclarationQueueConfig
 import com.github.gvolpe.fs2rabbit.config.deletion.{DeletionExchangeConfig, DeletionQueueConfig}
 import com.github.gvolpe.fs2rabbit.model.ExchangeType.ExchangeType
@@ -27,7 +28,7 @@ trait AMQPClient[F[_]] extends Binding[F] with Declaration[F] with Deletion[F] {
   def basicAck(channel: Channel, tag: DeliveryTag, multiple: Boolean): F[Unit]
   def basicNack(channel: Channel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit]
   def basicQos(channel: Channel, basicQos: BasicQos): F[Unit]
-  def basicConsume(channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Map[String, AnyRef])(internals: AMQPInternals): F[String]
+  def basicConsume(channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Arguments)(internals: AMQPInternals): F[String]
   def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[String]): F[Unit]
 }
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AckerConsumer.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AckerConsumer.scala
@@ -16,6 +16,7 @@
 
 package com.github.gvolpe.fs2rabbit.algebra
 
+import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.model.{AckResult, AmqpEnvelope, BasicQos, QueueName}
 import com.rabbitmq.client.Channel
 
@@ -30,6 +31,6 @@ trait AckerConsumer[F[_]] {
                      noLocal: Boolean = false,
                      exclusive: Boolean = false,
                      consumerTag: String = "",
-                     args: Map[String, AnyRef] = Map.empty[String, AnyRef]): F[AmqpEnvelope]
+                     args: Arguments = Map.empty): F[AmqpEnvelope]
 
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/arguments.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/arguments.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Fs2 Rabbit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.fs2rabbit
+
+import scala.language.implicitConversions
+
+import scala.collection.JavaConverters._
+
+object arguments {
+
+  type SafeArg   = Evidence[SafeArgument]
+  type Arguments = Map[String, SafeArg]
+
+  implicit def argumentConversion(arguments: Arguments): java.util.Map[String, Object] =
+    arguments.mapValues(x => x.ev.toObject(x.value)).asJava
+
+  sealed trait Evidence[F[_]] {
+    type A
+    val value: A
+    val ev: F[A]
+  }
+
+  final case class MkEvidence[F[_], A1](value: A1)(implicit val ev: F[A1]) extends Evidence[F] { type A = A1 }
+
+  implicit def anySafeArg[F[_], A: F](a: A): Evidence[F] = MkEvidence(a)
+
+  trait SafeArgument[A] {
+    type JavaType >: Null <: AnyRef
+    private[fs2rabbit] def toJavaType(a: A): JavaType
+    private[fs2rabbit] def toObject(a: A): Object = toJavaType(a)
+  }
+
+  object SafeArgument {
+    def apply[A](implicit ev: SafeArgument[A]): SafeArgument[A] = ev
+    def instance[A, J >: Null <: AnyRef](f: A => J): SafeArgument[A] =
+      new SafeArgument[A] {
+        type JavaType = J
+        def toJavaType(a: A) = f(a)
+      }
+
+    import scala.collection.JavaConverters._
+
+    implicit val stringInstance: SafeArgument[String]         = instance(identity)
+    implicit val bigDecimalInstance: SafeArgument[BigDecimal] = instance(_.bigDecimal)
+    implicit val intInstance: SafeArgument[Int]               = instance(Int.box)
+    implicit val longInstance: SafeArgument[Long]             = instance(Long.box)
+    implicit val doubleInstance: SafeArgument[Double]         = instance(Double.box)
+    implicit val floatInstance: SafeArgument[Float]           = instance(Float.box)
+    implicit val shortInstance: SafeArgument[Short]           = instance(Short.box)
+    implicit val booleanInstance: SafeArgument[Boolean]       = instance(Boolean.box)
+    implicit val byteInstance: SafeArgument[Byte]             = instance(Byte.box)
+    implicit val dateInstance: SafeArgument[java.util.Date]   = instance(identity)
+
+    implicit def listInstance[A: SafeArgument]: SafeArgument[List[A]]                   = instance(_.asJava)
+    implicit def mapInstance[K: SafeArgument, V: SafeArgument]: SafeArgument[Map[K, V]] = instance(_.asJava)
+  }
+
+}

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/config/declaration.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/config/declaration.scala
@@ -16,6 +16,7 @@
 
 package com.github.gvolpe.fs2rabbit.config
 
+import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.model.QueueName
 
 object declaration {
@@ -24,7 +25,7 @@ object declaration {
                                           durable: DurableCfg,
                                           exclusive: ExclusiveCfg,
                                           autoDelete: AutoDeleteCfg,
-                                          arguments: Map[String, AnyRef])
+                                          arguments: Arguments)
   object DeclarationQueueConfig {
 
     def default(queueName: QueueName): DeclarationQueueConfig =

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
@@ -16,6 +16,7 @@
 
 package com.github.gvolpe.fs2rabbit
 
+import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.rabbitmq.client.impl.LongStringHelper
 import com.rabbitmq.client.{AMQP, Channel, LongString, Connection => RabbitMQConnection}
 import fs2.{Sink, Stream}
@@ -35,7 +36,7 @@ object model {
   case class RoutingKey(value: String)   extends AnyVal
   case class DeliveryTag(value: Long)    extends AnyVal
 
-  case class ConsumerArgs(consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Map[String, AnyRef])
+  case class ConsumerArgs(consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Arguments)
   case class BasicQos(prefetchSize: Int, prefetchCount: Int, global: Boolean = false)
 
   object ExchangeType extends Enumeration {
@@ -59,9 +60,9 @@ object model {
       case LongVal(v)   => Long.box(v)
     }
   }
-  final case class IntVal(v: Int)       extends AmqpHeaderVal
-  final case class LongVal(v: Long)     extends AmqpHeaderVal
-  final case class StringVal(v: String) extends AmqpHeaderVal
+  final case class IntVal(value: Int)       extends AmqpHeaderVal
+  final case class LongVal(value: Long)     extends AmqpHeaderVal
+  final case class StringVal(value: String) extends AmqpHeaderVal
 
   object AmqpHeaderVal {
     def from(value: AnyRef): AmqpHeaderVal = value match {
@@ -107,11 +108,11 @@ object model {
   case class AmqpMessage[A](payload: A, properties: AmqpProperties)
 
   // Binding
-  case class QueueBindingArgs(value: Map[String, AnyRef])    extends AnyVal
-  case class ExchangeBindingArgs(value: Map[String, AnyRef]) extends AnyVal
+  case class QueueBindingArgs(value: Arguments)    extends AnyVal
+  case class ExchangeBindingArgs(value: Arguments) extends AnyVal
 
   // Declaration
-  case class QueueDeclarationArgs(value: Map[String, AnyRef])    extends AnyVal
-  case class ExchangeDeclarationArgs(value: Map[String, AnyRef]) extends AnyVal
+  case class QueueDeclarationArgs(value: Arguments)    extends AnyVal
+  case class ExchangeDeclarationArgs(value: Arguments) extends AnyVal
 
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerConsumerProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerConsumerProgram.scala
@@ -18,6 +18,7 @@ package com.github.gvolpe.fs2rabbit.program
 
 import cats.effect.{Async, IO}
 import com.github.gvolpe.fs2rabbit.algebra.{AMQPClient, AMQPInternals, AckerConsumer}
+import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.model._
 import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
@@ -50,7 +51,7 @@ class AckerConsumerProgram[F[_]](config: Fs2RabbitConfig, AMQP: AMQPClient[Strea
                               noLocal: Boolean = false,
                               exclusive: Boolean = false,
                               consumerTag: String = "",
-                              args: Map[String, AnyRef] = Map.empty[String, AnyRef]): StreamConsumer[F] =
+                              args: Arguments = Map.empty): StreamConsumer[F] =
     for {
       internalQ <- Stream.eval(F.liftIO(fs2.async.boundedQueue[IO, Either[Throwable, AmqpEnvelope]](500)))
       internals = AMQPInternals(Some(internalQ))

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/SafeArgSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/SafeArgSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Fs2 Rabbit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.fs2rabbit
+
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Assertion, FunSuite}
+
+class SafeArgSpec extends FunSuite with PropertyChecks {
+
+  import arguments._
+
+  def safeArg[A](value: A)(implicit ev: SafeArgument[A]): Assertion = {
+    assert(ev.toJavaType(value) != null)
+    assert(ev.toObject(value) != null)
+  }
+
+  def safeConversion(args: Arguments): Assertion = {
+    val converted: java.util.Map[String, Object] = args
+    assert(converted != null)
+  }
+
+  val tupleGen: Gen[(String, String)] =
+    for {
+      x <- Gen.alphaStr
+      y <- Gen.alphaStr
+    } yield (x, y)
+
+  val stringGen: Gen[String]           = Gen.alphaStr
+  val intGen: Gen[Int]                 = Gen.posNum[Int]
+  val longGen: Gen[Long]               = Gen.posNum[Long]
+  val doubleGen: Gen[Double]           = Gen.posNum[Double]
+  val floatGen: Gen[Float]             = Gen.posNum[Float]
+  val shortGen: Gen[Short]             = Gen.posNum[Short]
+  val booleanGen: Gen[Boolean]         = Gen.oneOf(Seq(true, false))
+  val byteGen: Gen[Byte]               = intGen.map(_.toByte)
+  val dateGen: Gen[java.util.Date]     = Gen.calendar.map(_.getTime)
+  val bigDecimalGen: Gen[BigDecimal]   = longGen.map(BigDecimal.apply)
+  val listGen: Gen[List[String]]       = Gen.listOf(stringGen)
+  val mapGen: Gen[Map[String, String]] = Gen.mapOf(tupleGen)
+
+  forAll(stringGen)(safeArg(_))
+  forAll(intGen)(safeArg(_))
+  forAll(longGen)(safeArg(_))
+  forAll(doubleGen)(safeArg(_))
+  forAll(floatGen)(safeArg(_))
+  forAll(shortGen)(safeArg(_))
+  forAll(booleanGen)(safeArg(_))
+  forAll(byteGen)(safeArg(_))
+  forAll(dateGen)(safeArg(_))
+  forAll(bigDecimalGen)(safeArg(_))
+  forAll(listGen)(safeArg(_))
+  forAll(mapGen)(safeArg(_))
+
+  test("Arguments conversion") {
+    safeConversion(Map("key" -> "value"))
+    safeConversion(Map("key" -> true))
+    safeConversion(Map("key" -> 123))
+    safeConversion(Map("key" -> 456L))
+    safeConversion(Map("key" -> 1.87))
+    safeConversion(Map("key" -> new java.util.Date()))
+    safeConversion(Map("key" -> "value".getBytes.toList))
+    safeConversion(Map("key" -> Map("nested" -> "value")))
+    safeConversion(Map("key" -> List(1, 2, 3)))
+  }
+
+}

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
@@ -19,6 +19,7 @@ package com.github.gvolpe.fs2rabbit.interpreter
 import cats.effect.IO
 import cats.syntax.apply._
 import com.github.gvolpe.fs2rabbit.algebra.{AMQPClient, AMQPInternals}
+import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.config.declaration.DeclarationQueueConfig
 import com.github.gvolpe.fs2rabbit.config.deletion.DeletionQueueConfig
 import com.github.gvolpe.fs2rabbit.config.{Fs2RabbitConfig, deletion}
@@ -67,7 +68,7 @@ class AMQPClientInMemory(ref: Ref[IO, AMQPInternals],
                             consumerTag: String,
                             noLocal: Boolean,
                             exclusive: Boolean,
-                            args: Map[String, AnyRef])(internals: AMQPInternals): Stream[IO, String] = {
+                            args: Arguments)(internals: AMQPInternals): Stream[IO, String] = {
     val ifError =
       raiseError[String](s"Queue ${queueName.value} does not exist!")
     queues.find(_.value == queueName.value).fold(ifError) { _ =>

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -150,7 +150,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           ackerQ            <- Stream.eval(async.boundedQueue[IO, AckResult](100))
           _                 <- declareExchange(exchangeName, ExchangeType.Topic)
           _                 <- declareQueue(DeclarationQueueConfig.default(queueName))
-          _                 <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty[String, AnyRef]))
+          _                 <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty))
           publisher         <- createPublisher(exchangeName, routingKey)
           msg               = Stream(AmqpMessage("acker-test", AmqpProperties.empty))
           _                 <- msg.covary[IO] to publisher
@@ -178,7 +178,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         ackerQ            <- Stream.eval(async.boundedQueue[IO, AckResult](100))
         _                 <- declareExchange(exchangeName, ExchangeType.Topic)
         _                 <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _                 <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty[String, AnyRef]))
+        _                 <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty))
         publisher         <- createPublisher(exchangeName, routingKey)
         msg               = Stream(AmqpMessage("NAck-test", AmqpProperties.empty))
         _                 <- msg.covary[IO] to publisher
@@ -227,7 +227,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           consumerArgs = ConsumerArgs(consumerTag = "XclusiveConsumer",
                                       noLocal = false,
                                       exclusive = true,
-                                      args = Map.empty[String, AnyRef])
+                                      args = Map.empty)
           consumer <- createAutoAckConsumer(queueName,
                                             BasicQos(prefetchSize = 0, prefetchCount = 10),
                                             Some(consumerArgs))
@@ -255,7 +255,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           consumerArgs = ConsumerArgs(consumerTag = "XclusiveConsumer",
                                       noLocal = false,
                                       exclusive = true,
-                                      args = Map.empty[String, AnyRef])
+                                      args = Map.empty)
           ackerConsumer <- createAckerConsumer(queueName,
                                                BasicQos(prefetchSize = 0, prefetchCount = 10),
                                                Some(consumerArgs))
@@ -283,7 +283,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         for {
           _ <- declareExchange(exchangeName, ExchangeType.Topic)
           _ <- declareQueue(DeclarationQueueConfig.default(queueName))
-          _ <- bindQueueNoWait(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty[String, AnyRef]))
+          _ <- bindQueueNoWait(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty))
         } yield ()
       }
   }
@@ -364,21 +364,18 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
     import interpreter._
     createConnectionChannel flatMap { implicit channel =>
       for {
-        testQ  <- Stream.eval(async.boundedQueue[IO, AmqpEnvelope](100))
-        ackerQ <- Stream.eval(async.boundedQueue[IO, AckResult](100))
-        _      <- declareExchange(sourceExchangeName, ExchangeType.Direct)
-        _      <- declareExchange(destinationExchangeName, ExchangeType.Direct)
-        _      <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _      <- bindQueue(queueName, destinationExchangeName, routingKey)
-        _ <- bindExchange(destinationExchangeName,
-                          sourceExchangeName,
-                          routingKey,
-                          ExchangeBindingArgs(Map.empty[String, AnyRef]))
+        testQ     <- Stream.eval(async.boundedQueue[IO, AmqpEnvelope](100))
+        ackerQ    <- Stream.eval(async.boundedQueue[IO, AckResult](100))
+        _         <- declareExchange(sourceExchangeName, ExchangeType.Direct)
+        _         <- declareExchange(destinationExchangeName, ExchangeType.Direct)
+        _         <- declareQueue(DeclarationQueueConfig.default(queueName))
+        _         <- bindQueue(queueName, destinationExchangeName, routingKey)
+        _         <- bindExchange(destinationExchangeName, sourceExchangeName, routingKey, ExchangeBindingArgs(Map.empty))
         publisher <- createPublisher(sourceExchangeName, routingKey)
         consumerArgs = ConsumerArgs(consumerTag = "XclusiveConsumer",
                                     noLocal = false,
                                     exclusive = true,
-                                    args = Map.empty[String, AnyRef])
+                                    args = Map.empty)
         ackerConsumer <- createAckerConsumer(queueName,
                                              BasicQos(prefetchSize = 0, prefetchCount = 10),
                                              Some(consumerArgs))
@@ -407,7 +404,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         ackerQ            <- Stream.eval(async.boundedQueue[IO, AckResult](100))
         _                 <- declareExchange(exchangeName, ExchangeType.Topic)
         _                 <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _                 <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty[String, AnyRef]))
+        _                 <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty))
         publisher         <- createPublisher(exchangeName, routingKey)
         msg               = Stream(AmqpMessage("NAck-test", AmqpProperties.empty))
         _                 <- msg.covary[IO] to publisher

--- a/site/src/main/tut/consumers/ackerconsumer.md
+++ b/site/src/main/tut/consumers/ackerconsumer.md
@@ -28,4 +28,4 @@ def program(implicit R: Fs2Rabbit[IO]) =
   }
 ```
 
-When creating a consumer, you can tune the configuration by using `BasicQos` and `ConsumerArgs`. By default, the `basic QOS` is set to a prefetch size of 0, a prefetch count of 1 and global is set to false. The `ConsumerArgs` is by default None since it's optional. When defined, you can indicate `consumerTag` (default is ""), `noLocal` (default is false), `exclusive` (default is false) and `args` (default is an empty `Map[String, AnyRef]`).
+When creating a consumer, you can tune the configuration by using `BasicQos` and `ConsumerArgs`. By default, the `basic QOS` is set to a prefetch size of 0, a prefetch count of 1 and global is set to false. The `ConsumerArgs` is by default None since it's optional. When defined, you can indicate `consumerTag` (default is ""), `noLocal` (default is false), `exclusive` (default is false) and `args` (default is an empty `Map[String, ?]`).

--- a/site/src/main/tut/consumers/autoackconsumer.md
+++ b/site/src/main/tut/consumers/autoackconsumer.md
@@ -27,4 +27,4 @@ def program(implicit R: Fs2Rabbit[IO]) =
   }
 ```
 
-When creating a consumer, you can tune the configuration by using `BasicQos` and `ConsumerArgs`. By default, the `basic QOS` is set to a prefetch size of 0, a prefetch count of 1 and global is set to false. The `ConsumerArgs` is by default None since it's optional. When defined, you can indicate `consumerTag` (default is ""), `noLocal` (default is false), `exclusive` (default is false) and `args` (default is an empty `Map[String, AnyRef]`).
+When creating a consumer, you can tune the configuration by using `BasicQos` and `ConsumerArgs`. By default, the `basic QOS` is set to a prefetch size of 0, a prefetch count of 1 and global is set to false. The `ConsumerArgs` is by default None since it's optional. When defined, you can indicate `consumerTag` (default is ""), `noLocal` (default is false), `exclusive` (default is false) and `args` (default is an empty `Map[String, ?]`).

--- a/site/src/main/tut/exchanges.md
+++ b/site/src/main/tut/exchanges.md
@@ -35,7 +35,7 @@ Two exchanges can be bound together by providing a `RoutingKey` and some extra a
 
 ```tut:book
 def binding(F: Fs2Rabbit[IO])(implicit channel: AMQPChannel) =
-  F.bindExchange(x1, x2, RoutingKey("rk"), ExchangeBindingArgs(Map.empty[String, AnyRef]))
+  F.bindExchange(x1, x2, RoutingKey("rk"), ExchangeBindingArgs(Map.empty))
 ```
 
 Read more about `Exchanges` and `ExchangeType` [here](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchanges).


### PR DESCRIPTION
It closes #50 

Using existential types to provide safe arguments based on the technique described [here](https://www.cakesolutions.net/teamblogs/existential-types-in-scala).

Replaces all the `Map[String, AnyRef]` for a safer version named `Arguments` that checks the types at compile time. This won't compile now for example:

```scala
DeclarationQueueConfig(
  queueName, 
  NonDurable, 
  NonExclusive, 
  NonAutoDelete, 
  Map("key" -> Yolo())
) // type mismatch, expected Arguments
```

However this compiles:
```scala
DeclarationQueueConfig(
  queueName, 
  NonDurable, 
  NonExclusive, 
  NonAutoDelete, 
  Map("key" -> true)
)
```

See `SafeArgsSpec` to see more supported types.

It matches all the types from here: https://github.com/rabbitmq/rabbitmq-java-client/blob/master/src/main/java/com/rabbitmq/client/impl/Frame.java#L256 except for `Array` since we support `List` and that's enough.

@insdami let me know what you think.