### PR TITLE
Removing unnecessary `()` from `() => Stream[F, Unit]` signature

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/StreamLoop.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/StreamLoop.scala
@@ -33,14 +33,14 @@ import scala.util.control.NonFatal
   *
   * By default the program will be restarted in 5 seconds, then 10, then 15, etc.
   *
-  * @see the StreamLoopSpec that demonstrates an use case.
+  * @see the StreamLoopSpec that demonstrates a use case.
   * */
 object StreamLoop {
 
   def run[F[_]](
-      program: () => Stream[F, Unit],
+      program: Stream[F, Unit],
       retry: FiniteDuration = 5.seconds)(implicit F: Effect[F], T: Timer[F], ec: ExecutionContext, L: Log[F]): F[Unit] =
-    loop(program(), retry, 1).compile.drain
+    loop(program, retry, 1).compile.drain
 
   private def loop[F[_]: Effect](program: Stream[F, Unit],
                                  retry: FiniteDuration,

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/StreamLoopSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/StreamLoopSpec.scala
@@ -43,7 +43,7 @@ class StreamLoopSpec extends FlatSpecLike with Matchers {
 
   it should "run a stream until it's finished" in IOAssertion {
     val program = Stream(1, 2, 3).covary[IO] to sink
-    StreamLoop.run(() => program)
+    StreamLoop.run(program)
   }
 
   it should "run a stream and recover in case of failure" in IOAssertion {
@@ -57,7 +57,7 @@ class StreamLoopSpec extends FlatSpecLike with Matchers {
         }
       }
 
-    async.refOf[IO, Int](2).flatMap(ref => StreamLoop.run(() => p(ref), 1.second))
+    async.refOf[IO, Int](2).flatMap(ref => StreamLoop.run(p(ref), 1.second))
   }
 
 }

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -16,7 +16,7 @@
 
 package com.github.gvolpe.fs2rabbit.interpreter
 
-import cats.effect.{IO, Timer}
+import cats.effect.IO
 import com.github.gvolpe.fs2rabbit.StreamAssertion
 import com.github.gvolpe.fs2rabbit.algebra.AMQPInternals
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
@@ -423,7 +423,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
   }
 
   def takeWithTimeOut[A](stream: Stream[IO, A], timeout: FiniteDuration): Stream[IO, Option[A]] =
-    stream.last.mergeHaltR(Stream.eval(Timer[IO].sleep(timeout)).map(_ => None: Option[A]))
+    stream.last.mergeHaltR(Stream.eval(IO.sleep(timeout)).map(_ => None: Option[A]))
 
   it should "create a publisher, two auto-ack consumers with different routing keys and assert the routing is correct" in StreamAssertion(
     TestFs2Rabbit(config)) { interpreter =>

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
@@ -38,6 +38,6 @@ object IOAckerConsumer extends IOApp {
 
   override def start(args: List[String]): IO[Unit] =
     Fs2Rabbit[IO](config).flatMap { implicit interpreter =>
-      StreamLoop.run(() => new AckerConsumerDemo[IO]().program)
+      StreamLoop.run(new AckerConsumerDemo[IO]().program)
     }
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -40,6 +40,6 @@ object MonixAutoAckConsumer extends IOApp {
 
   override def start(args: List[String]): IO[Unit] =
     Fs2Rabbit[Task](config).flatMap { implicit interpreter =>
-      StreamLoop.run(() => new AutoAckConsumerDemo[Task].program)
+      StreamLoop.run(new AutoAckConsumerDemo[Task].program)
     }.toIO
 }

--- a/site/src/main/tut/examples/sample-acker.md
+++ b/site/src/main/tut/examples/sample-acker.md
@@ -105,7 +105,7 @@ object IOAckerConsumer extends IOApp {
 
   override def start(args: List[String]): IO[Unit] =
     Fs2Rabbit[IO](config).flatMap { implicit interpreter =>
-      StreamLoop.run(() => new AckerConsumerDemo[IO]().program)
+      StreamLoop.run(new AckerConsumerDemo[IO]().program)
     }
 }
 ```

--- a/site/src/main/tut/examples/sample-autoack.md
+++ b/site/src/main/tut/examples/sample-autoack.md
@@ -105,7 +105,7 @@ object MonixAutoAckConsumer extends IOApp {
 
   override def start(args: List[String]): IO[Unit] =
     Fs2Rabbit[Task](config).flatMap { implicit interpreter =>
-      StreamLoop.run(() => new AutoAckConsumerDemo[Task].program)
+      StreamLoop.run(new AutoAckConsumerDemo[Task].program)
     }.toIO
 }
 ```

--- a/site/src/main/tut/resiliency.md
+++ b/site/src/main/tut/resiliency.md
@@ -6,9 +6,9 @@ number: 13
 
 # Resiliency
 
-If you want your program to run forever with automatic error recovery you can choose to run your program in a loop that will restart every certain amount of specified time with an exponential backoff. An useful `StreamLoop` object that you can use to achieve this is provided by the library.
+If you want your program to run forever with automatic error recovery you can choose to run your program in a loop that will restart every certain amount of specified time with an exponential backoff then `StreamLoop` is all you're looking for.
 
-So, for  given `Fs2 Rabbit` program defined as `Stream[F, Unit]`, a resilient app will look like follows:
+For a given `Fs2 Rabbit` program defined as `Stream[F, Unit]`, a resilient app will look as follow:
 
 ```tut:book
 import cats.effect.IO
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 
 val program: Stream[IO, Unit] = Stream.eval(IO.unit)
 
-StreamLoop.run(() => program, 1.second)
+StreamLoop.run(program, 1.second)
 ```
 
 This program will run forever and in the case of failure it will be restarted after 1 second and then exponentially after 2 seconds, 4 seconds, 8 seconds, etc.


### PR DESCRIPTION
Small refactor WRT `StreamLoop`