### PR TITLE
Renaming StreamLoop in favor of ResilientStream

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -23,8 +23,8 @@ import com.github.gvolpe.fs2rabbit.config.declaration.DeclarationQueueConfig
 import com.github.gvolpe.fs2rabbit.config.deletion
 import com.github.gvolpe.fs2rabbit.config.deletion.DeletionQueueConfig
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.typeclasses.BoolValue.syntax._
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.BoolValue.syntax._
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import com.rabbitmq.client._
 import fs2.Stream
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStream.scala
@@ -21,8 +21,8 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import com.github.gvolpe.fs2rabbit.algebra.Connection
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
+import com.github.gvolpe.fs2rabbit.util.{Log, StreamEval}
 import com.github.gvolpe.fs2rabbit.model.{AMQPChannel, RabbitChannel}
-import com.github.gvolpe.fs2rabbit.typeclasses.{Log, StreamEval}
 import com.rabbitmq.client.{ConnectionFactory, Connection => RabbitMQConnection}
 import fs2.Stream
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerConsumerProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerConsumerProgram.scala
@@ -22,7 +22,7 @@ import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.model.AckResult.{Ack, NAck}
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.{Pipe, Sink, Stream}
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/ConsumingProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/ConsumingProgram.scala
@@ -19,7 +19,7 @@ package com.github.gvolpe.fs2rabbit.program
 import cats.effect.Async
 import com.github.gvolpe.fs2rabbit.algebra.{AckerConsumer, Consuming}
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.Stream
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/PublishingProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/PublishingProgram.scala
@@ -19,7 +19,7 @@ package com.github.gvolpe.fs2rabbit.program
 import cats.effect.Sync
 import com.github.gvolpe.fs2rabbit.algebra.{AMQPClient, Publishing}
 import com.github.gvolpe.fs2rabbit.model.{ExchangeName, RoutingKey, StreamPublisher}
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.Stream
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStream.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit
+package com.github.gvolpe.fs2rabbit.resiliency
 
 import cats.effect.{Effect, Timer}
-import com.github.gvolpe.fs2rabbit.typeclasses.Log
+import com.github.gvolpe.fs2rabbit.util.Log
 import fs2.Stream
 
 import scala.concurrent.ExecutionContext
@@ -33,9 +33,9 @@ import scala.util.control.NonFatal
   *
   * By default the program will be restarted in 5 seconds, then 10, then 15, etc.
   *
-  * @see the StreamLoopSpec that demonstrates a use case.
+  * @see ResilientStreamSpec for more.
   * */
-object StreamLoop {
+object ResilientStream {
 
   def run[F[_]](
       program: Stream[F, Unit],

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/BoolValue.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/BoolValue.scala
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit.typeclasses
+package com.github.gvolpe.fs2rabbit.util
 
 import com.github.gvolpe.fs2rabbit.config.declaration._
 import com.github.gvolpe.fs2rabbit.config.deletion.{Empty, IfEmptyCfg, IfUnusedCfg, Unused}
 
 trait BoolValue[A] {
   def isTrue(a: A): Boolean
-  def isFalse(a: A): Boolean =
-    !isTrue(a)
+  def isFalse(a: A): Boolean = !isTrue(a)
 }
 
 object BoolValue {

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/Log.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/Log.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit.typeclasses
+package com.github.gvolpe.fs2rabbit.util
 
 import cats.effect.Sync
 import org.slf4j.LoggerFactory

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/StreamEval.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/StreamEval.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit.typeclasses
+package com.github.gvolpe.fs2rabbit.util
 
 import cats.effect.Sync
 import fs2.{Pipe, Sink, Stream}

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStub.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStub.scala
@@ -19,7 +19,7 @@ package com.github.gvolpe.fs2rabbit.interpreter
 import cats.effect.IO
 import com.github.gvolpe.fs2rabbit.algebra.Connection
 import com.github.gvolpe.fs2rabbit.model.AMQPChannel
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.Stream
 

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStreamSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStreamSpec.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit
+package com.github.gvolpe.fs2rabbit.resiliency
 
 import cats.effect.IO
 import cats.syntax.apply._
-import com.github.gvolpe.fs2rabbit.typeclasses.Log
+import com.github.gvolpe.fs2rabbit.util.Log
 import fs2._
 import fs2.async.Ref
 import org.scalatest.{FlatSpecLike, Matchers}
@@ -26,7 +26,7 @@ import org.scalatest.{FlatSpecLike, Matchers}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-class StreamLoopSpec extends FlatSpecLike with Matchers {
+class ResilientStreamSpec extends FlatSpecLike with Matchers {
 
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
@@ -43,7 +43,7 @@ class StreamLoopSpec extends FlatSpecLike with Matchers {
 
   it should "run a stream until it's finished" in IOAssertion {
     val program = Stream(1, 2, 3).covary[IO] to sink
-    StreamLoop.run(program)
+    ResilientStream.run(program)
   }
 
   it should "run a stream and recover in case of failure" in IOAssertion {
@@ -57,7 +57,7 @@ class StreamLoopSpec extends FlatSpecLike with Matchers {
         }
       }
 
-    async.refOf[IO, Int](2).flatMap(ref => StreamLoop.run(p(ref), 1.second))
+    async.refOf[IO, Int](2).flatMap(ref => ResilientStream.run(p(ref), 1.second))
   }
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AckerConsumerDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AckerConsumerDemo.scala
@@ -23,7 +23,7 @@ import com.github.gvolpe.fs2rabbit.json.Fs2JsonEncoder
 import com.github.gvolpe.fs2rabbit.model.AckResult.Ack
 import com.github.gvolpe.fs2rabbit.model.AmqpHeaderVal.{LongVal, StringVal}
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import fs2.{Pipe, Stream}
 
 import scala.concurrent.ExecutionContext

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AutoAckConsumerDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AutoAckConsumerDemo.scala
@@ -23,7 +23,7 @@ import com.github.gvolpe.fs2rabbit.json.Fs2JsonEncoder
 import com.github.gvolpe.fs2rabbit.model.AckResult.Ack
 import com.github.gvolpe.fs2rabbit.model.AmqpHeaderVal.{LongVal, StringVal}
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import fs2.{Pipe, Stream}
 
 import scala.concurrent.ExecutionContext

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
@@ -17,9 +17,9 @@
 package com.github.gvolpe.fs2rabbit.examples
 
 import cats.effect.IO
-import com.github.gvolpe.fs2rabbit.StreamLoop
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
+import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 
 import scala.concurrent.ExecutionContext
 
@@ -38,6 +38,6 @@ object IOAckerConsumer extends IOApp {
 
   override def start(args: List[String]): IO[Unit] =
     Fs2Rabbit[IO](config).flatMap { implicit interpreter =>
-      StreamLoop.run(new AckerConsumerDemo[IO]().program)
+      ResilientStream.run(new AckerConsumerDemo[IO]().program)
     }
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -17,9 +17,9 @@
 package com.github.gvolpe.fs2rabbit.examples
 
 import cats.effect.IO
-import com.github.gvolpe.fs2rabbit.StreamLoop
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
+import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
@@ -40,6 +40,6 @@ object MonixAutoAckConsumer extends IOApp {
 
   override def start(args: List[String]): IO[Unit] =
     Fs2Rabbit[Task](config).flatMap { implicit interpreter =>
-      StreamLoop.run(new AutoAckConsumerDemo[Task].program)
+      ResilientStream.run(new AutoAckConsumerDemo[Task].program)
     }.toIO
 }

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
@@ -17,8 +17,8 @@
 package com.github.gvolpe.fs2rabbit.json
 
 import cats.effect.Sync
+import com.github.gvolpe.fs2rabbit.util.{Log, StreamEval}
 import com.github.gvolpe.fs2rabbit.model.{AmqpEnvelope, DeliveryTag}
-import com.github.gvolpe.fs2rabbit.typeclasses.{Log, StreamEval}
 import fs2.{Pipe, Stream}
 import io.circe.parser.decode
 import io.circe.{Decoder, Error}

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
@@ -18,7 +18,7 @@ package com.github.gvolpe.fs2rabbit.json
 
 import cats.effect.Sync
 import com.github.gvolpe.fs2rabbit.model.AmqpMessage
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import fs2.Pipe
 import io.circe.Encoder
 import io.circe.syntax._

--- a/site/src/main/tut/examples/sample-acker.md
+++ b/site/src/main/tut/examples/sample-acker.md
@@ -16,7 +16,7 @@ import com.github.gvolpe.fs2rabbit.json.Fs2JsonEncoder
 import com.github.gvolpe.fs2rabbit.model.AckResult._
 import com.github.gvolpe.fs2rabbit.model.AmqpHeaderVal._
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import fs2.{Pipe, Stream}
 
 import scala.concurrent.ExecutionContext
@@ -84,9 +84,9 @@ At the edge of out program we define our effect, `cats.effect.IO` in this case, 
 
 ```tut:book:silent
 import cats.effect.IO
-import com.github.gvolpe.fs2rabbit.StreamLoop
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
+import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 
 import scala.concurrent.ExecutionContext
 
@@ -105,7 +105,7 @@ object IOAckerConsumer extends IOApp {
 
   override def start(args: List[String]): IO[Unit] =
     Fs2Rabbit[IO](config).flatMap { implicit interpreter =>
-      StreamLoop.run(new AckerConsumerDemo[IO]().program)
+      ResilientStream.run(new AckerConsumerDemo[IO]().program)
     }
 }
 ```

--- a/site/src/main/tut/examples/sample-autoack.md
+++ b/site/src/main/tut/examples/sample-autoack.md
@@ -16,7 +16,7 @@ import com.github.gvolpe.fs2rabbit.json.Fs2JsonEncoder
 import com.github.gvolpe.fs2rabbit.model.AckResult._
 import com.github.gvolpe.fs2rabbit.model.AmqpHeaderVal._
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.typeclasses.StreamEval
+import com.github.gvolpe.fs2rabbit.util.StreamEval
 import fs2.{Pipe, Stream}
 
 import scala.concurrent.ExecutionContext
@@ -82,9 +82,9 @@ At the edge of out program we define our effect, `monix.eval.Task` in this case,
 
 ```tut:book:silent
 import cats.effect.IO
-import com.github.gvolpe.fs2rabbit.StreamLoop
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
+import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
@@ -105,7 +105,7 @@ object MonixAutoAckConsumer extends IOApp {
 
   override def start(args: List[String]): IO[Unit] =
     Fs2Rabbit[Task](config).flatMap { implicit interpreter =>
-      StreamLoop.run(new AutoAckConsumerDemo[Task].program)
+      ResilientStream.run(new AutoAckConsumerDemo[Task].program)
     }.toIO
 }
 ```

--- a/site/src/main/tut/resiliency.md
+++ b/site/src/main/tut/resiliency.md
@@ -6,13 +6,13 @@ number: 13
 
 # Resiliency
 
-If you want your program to run forever with automatic error recovery you can choose to run your program in a loop that will restart every certain amount of specified time with an exponential backoff then `StreamLoop` is all you're looking for.
+If you want your program to run forever with automatic error recovery you can choose to run your program in a loop that will restart every certain amount of specified time with an exponential backoff then `ResilientStream` is all you're looking for.
 
 For a given `Fs2 Rabbit` program defined as `Stream[F, Unit]`, a resilient app will look as follow:
 
 ```tut:book
 import cats.effect.IO
-import com.github.gvolpe.fs2rabbit.StreamLoop
+import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 import fs2._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 
 val program: Stream[IO, Unit] = Stream.eval(IO.unit)
 
-StreamLoop.run(program, 1.second)
+ResilientStream.run(program, 1.second)
 ```
 
 This program will run forever and in the case of failure it will be restarted after 1 second and then exponentially after 2 seconds, 4 seconds, 8 seconds, etc.


### PR DESCRIPTION
Towards a `1.0` release I made the following changes:

- Renamed `StreamLoop` to `ResilientStream` since it makes more sense IMO.
- Renamed package `typeclasses` to `util` since there were no "typeclasses" here but just datatypes.