### PR TITLE
Remove Sync constraint on Fs2Json[En|De]coder

### DIFF
--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
@@ -27,7 +27,7 @@ import io.circe.{Decoder, Error}
   * Stream-based Json Decoder that exposes only one method as a streaming transformation
   * using [[fs2.Pipe]] and depends on the Circe library.
   * */
-class Fs2JsonDecoder[F[_]: Sync](implicit L: Log[F], SE: StreamEval[F]) {
+class Fs2JsonDecoder[F[_]](implicit L: Log[F], SE: StreamEval[F]) {
 
   /**
     * It tries to decode an [[AmqpEnvelope.payload]] into a case class determined by the parameter [A].

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
@@ -27,7 +27,7 @@ import io.circe.syntax._
   * Stream-based Json Encoder that exposes only one method as a streaming transformation
   * using [[fs2.Pipe]] and depends on the Circe library.
   * */
-class Fs2JsonEncoder[F[_]: Sync](implicit SE: StreamEval[F]) {
+class Fs2JsonEncoder[F[_]](implicit SE: StreamEval[F]) {
 
   /**
     * It tries to encode a given case class encapsulated in an  [[AmqpMessage]] into a


### PR DESCRIPTION
The `Sync` constraint on the Decoder/Encoder does not seem to be necessary. 