### PR TITLE
Custom JSON printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Check the [official guide](https://gvolpe.github.io/fs2-rabbit/guide.html) for u
 | [Cognotekt](http://www.cognotekt.com/en) | Microservice workflow management in Insuretech AI applications. |
 | [Klarna](https://www.klarna.com/us/) | Microservice for Fintech services. |
 | [Philips Lighting](http://www.lighting.philips.com/main/home) | Internal microservices interaction. |
+| [Free2Move](https://free2move.com) | Microservice communication. |
 
 ## LICENSE
 

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
@@ -16,11 +16,11 @@
 
 package com.github.gvolpe.fs2rabbit.json
 
-import cats.effect.Sync
 import com.github.gvolpe.fs2rabbit.model.AmqpMessage
 import com.github.gvolpe.fs2rabbit.util.StreamEval
 import fs2.Pipe
 import io.circe.Encoder
+import io.circe.Printer
 import io.circe.syntax._
 
 /**
@@ -28,6 +28,12 @@ import io.circe.syntax._
   * using [[fs2.Pipe]] and depends on the Circe library.
   * */
 class Fs2JsonEncoder[F[_]](implicit SE: StreamEval[F]) {
+
+  /**
+    * The [[io.circe.Printer]] to be used to convert to JSON - overwrite if you need different output formatting,
+    * for example, to omit null values.
+    */
+  val printer: Printer = Printer.noSpaces
 
   /**
     * It tries to encode a given case class encapsulated in an  [[AmqpMessage]] into a
@@ -50,7 +56,7 @@ class Fs2JsonEncoder[F[_]](implicit SE: StreamEval[F]) {
     streamMsg =>
       for {
         amqpMsg <- streamMsg
-        json    <- SE.evalF[String](amqpMsg.payload.asJson.noSpaces)
+        json    <- SE.evalF[String](amqpMsg.payload.asJson.pretty(printer))
       } yield AmqpMessage(json, amqpMsg.properties)
 
 }

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
@@ -26,14 +26,11 @@ import io.circe.syntax._
 /**
   * Stream-based Json Encoder that exposes only one method as a streaming transformation
   * using [[fs2.Pipe]] and depends on the Circe library.
+  *
+  * @param printer The [[io.circe.Printer]] to be used to convert to JSON - overwrite if you need different
+  *                output formatting, for example, to omit null values.
   * */
-class Fs2JsonEncoder[F[_]](implicit SE: StreamEval[F]) {
-
-  /**
-    * The [[io.circe.Printer]] to be used to convert to JSON - overwrite if you need different output formatting,
-    * for example, to omit null values.
-    */
-  val printer: Printer = Printer.noSpaces
+class Fs2JsonEncoder[F[_]](printer: Printer = Printer.noSpaces)(implicit SE: StreamEval[F]) {
 
   /**
     * It tries to encode a given case class encapsulated in an  [[AmqpMessage]] into a

--- a/json-circe/src/test/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoderSpec.scala
+++ b/json-circe/src/test/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoderSpec.scala
@@ -58,9 +58,7 @@ class Fs2JsonEncoderSpec extends FlatSpecLike with Matchers {
   it should "encode a simple case class according to a custom printer" in {
     val payload = Address(212, "Baker St")
 
-    val customFs2JsonEncoder = new Fs2JsonEncoder[IO] {
-      override val printer: Printer = Printer.spaces4
-    }
+    val customFs2JsonEncoder = new Fs2JsonEncoder[IO](Printer.spaces4)
 
     val test = for {
       json <- Stream(AmqpMessage(payload, AmqpProperties.empty)).covary[IO] through customFs2JsonEncoder

--- a/site/src/main/tut/publishers/json.md
+++ b/site/src/main/tut/publishers/json.md
@@ -25,3 +25,5 @@ def program(publisher: StreamPublisher[IO]) = {
   Stream(message).covary[IO] through jsonEncode[Person] to publisher
 }
 ```
+
+If you need to modify the output format, you can overwrite `printer` to plug in your own `io.circe.Printer`.

--- a/site/src/main/tut/publishers/json.md
+++ b/site/src/main/tut/publishers/json.md
@@ -26,4 +26,4 @@ def program(publisher: StreamPublisher[IO]) = {
 }
 ```
 
-If you need to modify the output format, you can overwrite `printer` to plug in your own `io.circe.Printer`.
+If you need to modify the output format, you can pass your own `io.circe.Printer` to the constructor of `Fs2JsonEncoder` (defaults to `Printer.noSpaces`).


### PR DESCRIPTION
In our use case, we need to omit `None` values from the output JSON, but Circe by default encodes them as explicit `null` values. The output format is controller by an instance `io.circe.Printer`, but fs2-rabbit so far hardcodes this to `Printer.noSpaces`. This PR factors this out to a field on `Fs2JsonEncoder` to allow users to override the default `Printer` - example is in tests, docs have been updated as well. Any questions or comments, just let me know :)