### PR TITLE
Fix bug where headers with arrays would throw a `MatchError` exception.

### DIFF
--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/AmqpHeaderValSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/AmqpHeaderValSpec.scala
@@ -26,11 +26,13 @@ class AmqpHeaderValSpec extends FlatSpecLike with Matchers {
     val intVal    = IntVal(1)
     val longVal   = LongVal(2L)
     val stringVal = StringVal("hey")
+    val arrayVal = ArrayVal(Seq(3, 2, 1))
 
     AmqpHeaderVal.from(intVal.impure) should be(intVal)
     AmqpHeaderVal.from(longVal.impure) should be(longVal)
     AmqpHeaderVal.from(stringVal.impure) should be(stringVal)
     AmqpHeaderVal.from("fs2") should be(StringVal("fs2"))
+    AmqpHeaderVal.from(arrayVal.impure) should be(ArrayVal(Seq(3, 2, 1)))
   }
 
 }


### PR DESCRIPTION
Apparently header values can be arrays, in which case fs2-rabbit would throw `MatchError` when trying to convert them to `AmqpHeaderVal`, which prevented it from consuming messages.

Aparently there are other types that are not supported and will cause the same error: https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_3
