### PR TITLE
Add support of all standard message properties

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
@@ -96,22 +96,34 @@ object model {
     }
   }
 
-  case class AmqpProperties(contentType: Option[String],
-                            contentEncoding: Option[String],
-                            priority: Option[Int],
-                            deliveryMode: Option[DeliveryMode],
-                            headers: Map[String, AmqpHeaderVal])
+  case class AmqpProperties(contentType: Option[String] = None,
+                            contentEncoding: Option[String] = None,
+                            priority: Option[Int] = None,
+                            deliveryMode: Option[DeliveryMode] = None,
+                            correlationId: Option[String] = None,
+                            messageId: Option[String] = None,
+                            `type`: Option[String] = None,
+                            userId: Option[String] = None,
+                            appId: Option[String] = None,
+                            expiration: Option[String] = None,
+                            headers: Map[String, AmqpHeaderVal] = Map.empty)
 
   object AmqpProperties {
-    def empty = AmqpProperties(None, None, None, None, Map.empty[String, AmqpHeaderVal])
+    def empty = AmqpProperties()
 
     def from(basicProps: AMQP.BasicProperties): AmqpProperties =
       AmqpProperties(
-        Option(basicProps.getContentType),
-        Option(basicProps.getContentEncoding),
-        Option[Integer](basicProps.getPriority).map(Int.unbox),
-        Option(basicProps.getDeliveryMode).map(DeliveryMode.from(_)),
-        Option(basicProps.getHeaders)
+        contentType = Option(basicProps.getContentType),
+        contentEncoding = Option(basicProps.getContentEncoding),
+        priority = Option[Integer](basicProps.getPriority).map(Int.unbox),
+        deliveryMode = Option(basicProps.getDeliveryMode).map(DeliveryMode.from(_)),
+        correlationId = Option(basicProps.getCorrelationId),
+        messageId = Option(basicProps.getMessageId),
+        `type` = Option(basicProps.getType),
+        userId = Option(basicProps.getUserId),
+        appId = Option(basicProps.getAppId),
+        expiration = Option(basicProps.getExpiration),
+        headers = Option(basicProps.getHeaders)
           .fold(Map.empty[String, Object])(_.asScala.toMap)
           .map {
             case (k, v) => k -> AmqpHeaderVal.from(v)
@@ -125,6 +137,12 @@ object model {
           .contentEncoding(props.contentEncoding.orNull)
           .priority(props.priority.map(Int.box).orNull)
           .deliveryMode(props.deliveryMode.map(i => Int.box(i.value)).orNull)
+          .correlationId(props.correlationId.orNull)
+          .messageId(props.messageId.orNull)
+          .`type`(props.`type`.orNull)
+          .appId(props.appId.orNull)
+          .userId(props.userId.orNull)
+          .expiration(props.expiration.orNull)
           .headers(props.headers.mapValues[AnyRef](_.impure).asJava)
           .build()
     }

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/AmqpPropertiesSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/AmqpPropertiesSpec.scala
@@ -34,7 +34,8 @@ class AmqpPropertiesSpec extends FlatSpecLike with Matchers with AmqpPropertiesA
   }
 
   it should "create an empty amqp properties" in {
-    AmqpProperties.empty should be(AmqpProperties(None, None, None, None, Map.empty[String, AmqpHeaderVal]))
+    AmqpProperties.empty should be(
+      AmqpProperties(None, None, None, None, None, None, None, None, None, None, Map.empty[String, AmqpHeaderVal]))
   }
 
   it should "handle null values in Java AMQP.BasicProperties" in {
@@ -73,8 +74,25 @@ trait AmqpPropertiesArbitraries extends PropertyChecks {
       contentEncoding <- Gen.option(Gen.alphaStr)
       priority        <- Gen.option(Gen.posNum[Int])
       deliveryMode    <- Gen.option(Gen.oneOf(1, 2))
+      correlationId   <- Gen.option(Gen.alphaNumStr)
+      messageId       <- Gen.option(Gen.alphaNumStr)
+      messageType     <- Gen.option(Gen.alphaStr)
+      userId          <- Gen.option(Gen.alphaNumStr)
+      appId           <- Gen.option(Gen.alphaNumStr)
+      expiration      <- Gen.option(Gen.alphaNumStr)
       headers         <- Gen.mapOf[String, AmqpHeaderVal](headersGen)
-    } yield AmqpProperties(contentType, contentEncoding, priority, deliveryMode.map(DeliveryMode.from), headers)
+    } yield
+      AmqpProperties(contentType,
+                     contentEncoding,
+                     priority,
+                     deliveryMode.map(DeliveryMode.from),
+                     correlationId,
+                     messageId,
+                     messageType,
+                     userId,
+                     appId,
+                     expiration,
+                     headers)
   }
 
 }

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -171,10 +171,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           result    <- Stream.eval(testQ.dequeue1)
           ackResult <- Stream.eval(ackerQ.dequeue1)
         } yield {
-          result should be(
-            AmqpEnvelope(DeliveryTag(1),
-                         "acker-test",
-                         AmqpProperties(None, None, None, None, Map.empty[String, AmqpHeaderVal])))
+          result should be(AmqpEnvelope(DeliveryTag(1), "acker-test", AmqpProperties()))
           ackResult should be(Ack(DeliveryTag(1)))
         }
       }
@@ -198,10 +195,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         _                 <- (Stream(NAck(DeliveryTag(1))).covary[IO].observe(ackerQ.enqueue) to acker).take(1)
         ackResult         <- Stream.eval(ackerQ.dequeue1)
       } yield {
-        result should be(
-          AmqpEnvelope(DeliveryTag(1),
-                       "NAck-test",
-                       AmqpProperties(None, None, None, None, Map.empty[String, AmqpHeaderVal])))
+        result should be(AmqpEnvelope(DeliveryTag(1), "NAck-test", AmqpProperties()))
         ackResult should be(NAck(DeliveryTag(1)))
       }
     }
@@ -221,10 +215,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         _         <- msg.covary[IO] to publisher
         result    <- consumer.take(1)
       } yield {
-        result should be(
-          AmqpEnvelope(DeliveryTag(1),
-                       "test",
-                       AmqpProperties(None, None, None, None, Map.empty[String, AmqpHeaderVal])))
+        result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties()))
       }
     }
   }
@@ -249,10 +240,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           _      <- msg.covary[IO] to publisher
           result <- consumer.take(1)
         } yield {
-          result should be(
-            AmqpEnvelope(DeliveryTag(1),
-                         "test",
-                         AmqpProperties(None, None, None, None, Map.empty[String, AmqpHeaderVal])))
+          result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties()))
         }
       }
   }
@@ -285,10 +273,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           result    <- Stream.eval(testQ.dequeue1)
           ackResult <- Stream.eval(ackerQ.dequeue1)
         } yield {
-          result should be(
-            AmqpEnvelope(DeliveryTag(1),
-                         "test",
-                         AmqpProperties(None, None, None, None, Map.empty[String, AmqpHeaderVal])))
+          result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties()))
           ackResult should be(Ack(DeliveryTag(1)))
         }
       }
@@ -407,10 +392,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         result    <- Stream.eval(testQ.dequeue1)
         ackResult <- Stream.eval(ackerQ.dequeue1)
       } yield {
-        result should be(
-          AmqpEnvelope(DeliveryTag(1),
-                       "test",
-                       AmqpProperties(None, None, None, None, Map.empty[String, AmqpHeaderVal])))
+        result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties()))
         ackResult should be(Ack(DeliveryTag(1)))
       }
     }
@@ -463,10 +445,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         result    <- c1.take(1)
         rs2       <- takeWithTimeOut(c2, 1.second)
       } yield {
-        result should be(
-          AmqpEnvelope(DeliveryTag(1),
-                       "test",
-                       AmqpProperties(None, None, None, None, Map.empty[String, AmqpHeaderVal])))
+        result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties()))
         rs2 should be(None)
       }
     }

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AckerConsumerDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AckerConsumerDemo.scala
@@ -67,9 +67,7 @@ class Flow[F[_]: Concurrent](consumer: StreamConsumer[F],
   import jsonEncoder.jsonEncode
 
   val simpleMessage =
-    AmqpMessage(
-      "Hey!",
-      AmqpProperties(None, None, None, None, Map("demoId" -> LongVal(123), "app" -> StringVal("fs2RabbitDemo"))))
+    AmqpMessage("Hey!", AmqpProperties(headers = Map("demoId" -> LongVal(123), "app" -> StringVal("fs2RabbitDemo"))))
   val classMessage = AmqpMessage(Person(1L, "Sherlock", Address(212, "Baker St")), AmqpProperties.empty)
 
   val flow: Stream[F, Unit] =

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AutoAckConsumerDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AutoAckConsumerDemo.scala
@@ -65,9 +65,7 @@ class AutoAckFlow[F[_]: Concurrent](consumer: StreamConsumer[F],
   import jsonEncoder.jsonEncode
 
   val simpleMessage =
-    AmqpMessage(
-      "Hey!",
-      AmqpProperties(None, None, None, None, Map("demoId" -> LongVal(123), "app" -> StringVal("fs2RabbitDemo"))))
+    AmqpMessage("Hey!", AmqpProperties(headers = Map("demoId" -> LongVal(123), "app" -> StringVal("fs2RabbitDemo"))))
   val classMessage = AmqpMessage(Person(1L, "Sherlock", Address(212, "Baker St")), AmqpProperties.empty)
 
   val flow: Stream[F, Unit] =

--- a/site/src/main/tut/examples/sample-acker.md
+++ b/site/src/main/tut/examples/sample-acker.md
@@ -35,7 +35,7 @@ class Flow[F[_]: Concurrent](consumer: StreamConsumer[F],
   val simpleMessage =
     AmqpMessage(
         "Hey!",
-        AmqpProperties(None, None, None, None, Map("demoId" -> LongVal(123), "app" -> StringVal("fs2RabbitDemo"))))
+        AmqpProperties(headers = Map("demoId" -> LongVal(123), "app" -> StringVal("fs2RabbitDemo"))))
   val classMessage = AmqpMessage(Person(1L, "Sherlock", Address(212, "Baker St")), AmqpProperties.empty)
 
   val flow: Stream[F, Unit] =

--- a/site/src/main/tut/examples/sample-autoack.md
+++ b/site/src/main/tut/examples/sample-autoack.md
@@ -35,7 +35,7 @@ class AutoAckFlow[F[_]: Concurrent](
   val simpleMessage =
     AmqpMessage(
         "Hey!",
-        AmqpProperties(None, None, None, None, Map("demoId" -> LongVal(123), "app" -> StringVal("fs2RabbitDemo"))))
+        AmqpProperties(headers = Map("demoId" -> LongVal(123), "app" -> StringVal("fs2RabbitDemo"))))
   val classMessage = AmqpMessage(Person(1L, "Sherlock", Address(212, "Baker St")), AmqpProperties.empty)
 
   val flow: Stream[F, Unit] =


### PR DESCRIPTION
AmqpProperties previously supported:
- content-type
- content-encoding
- delivery-mode
- priority

This adds support for the following properties:
- correlation-id
- message-id
- type
- app-id
- user-id
- expiration

Additionally, you can still set custom headers in `headers`.

Documentation and examples are up-to-date.

Close #85 