### PR TITLE
Add missing exchange declarations

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
@@ -41,6 +41,7 @@ trait Binding[F[_]] {
 
 trait Declaration[F[_]] {
   def declareExchange(channel: Channel, exchangeConfig: DeclarationExchangeConfig): F[Unit]
+  def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): F[Unit]
   def declareQueue(channel: Channel, queueConfig: DeclarationQueueConfig): F[Unit]
   def declareQueueNoWait(channel: Channel, queueConfig: DeclarationQueueConfig): F[Unit]
   def declareQueuePassive(channel: Channel, queueName: QueueName): F[Unit]

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
@@ -24,6 +24,7 @@ import com.rabbitmq.client.Channel
 
 // format: off
 trait AMQPClient[F[_], G[_]] extends Binding[F] with Declaration[F] with Deletion[F] {
+
   def basicAck(channel: Channel, tag: DeliveryTag, multiple: Boolean): F[Unit]
   def basicNack(channel: Channel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit]
   def basicQos(channel: Channel, basicQos: BasicQos): F[Unit]
@@ -41,6 +42,7 @@ trait Binding[F[_]] {
 
 trait Declaration[F[_]] {
   def declareExchange(channel: Channel, exchangeConfig: DeclarationExchangeConfig): F[Unit]
+  def declareExchangeNoWait(value: Channel, exchangeConfig: DeclarationExchangeConfig): F[Unit]
   def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): F[Unit]
   def declareQueue(channel: Channel, queueConfig: DeclarationQueueConfig): F[Unit]
   def declareQueueNoWait(channel: Channel, queueConfig: DeclarationQueueConfig): F[Unit]

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -144,6 +144,10 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
     )
   }
 
+  override def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): Stream[F, Unit] = SE.evalF {
+    channel.exchangeDeclarePassive(exchangeName.value)
+  }
+
   override def declareQueue(channel: Channel, config: DeclarationQueueConfig): Stream[F, Unit] = SE.evalF {
     channel.queueDeclare(
       config.queueName.value,

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -144,6 +144,18 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
     )
   }
 
+  override def declareExchangeNoWait(channel: Channel, config: DeclarationExchangeConfig): Stream[F, Unit] =
+    SE.evalF {
+      channel.exchangeDeclareNoWait(
+        config.exchangeName.value,
+        config.exchangeType.toString.toLowerCase,
+        config.durable.isTrue,
+        config.autoDelete.isTrue,
+        config.internal.isTrue,
+        config.arguments
+      )
+    }
+
   override def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): Stream[F, Unit] = SE.evalF {
     channel.exchangeDeclarePassive(exchangeName.value)
   }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -95,6 +95,9 @@ class Fs2Rabbit[F[_]: Concurrent](config: Fs2RabbitConfig,
   def declareExchange(exchangeConfig: DeclarationExchangeConfig)(implicit channel: AMQPChannel): Stream[F, Unit] =
     amqpClient.declareExchange(channel.value, exchangeConfig)
 
+  def declareExchangeNoWait(exchangeConfig: DeclarationExchangeConfig)(implicit channel: AMQPChannel): Stream[F, Unit] =
+    amqpClient.declareExchangeNoWait(channel.value, exchangeConfig)
+
   def declareExchangePassive(exchangeName: ExchangeName)(implicit channel: AMQPChannel): Stream[F, Unit] =
     amqpClient.declareExchangePassive(channel.value, exchangeName)
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -95,6 +95,9 @@ class Fs2Rabbit[F[_]: Concurrent](config: Fs2RabbitConfig,
   def declareExchange(exchangeConfig: DeclarationExchangeConfig)(implicit channel: AMQPChannel): Stream[F, Unit] =
     amqpClient.declareExchange(channel.value, exchangeConfig)
 
+  def declareExchangePassive(exchangeName: ExchangeName)(implicit channel: AMQPChannel): Stream[F, Unit] =
+    amqpClient.declareExchangePassive(channel.value, exchangeName)
+
   def declareQueue(queueConfig: DeclarationQueueConfig)(implicit channel: AMQPChannel): Stream[F, Unit] =
     amqpClient.declareQueue(channel.value, queueConfig)
 

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
@@ -131,6 +131,9 @@ class AMQPClientInMemory(ref: Ref[IO, AMQPInternals[IO]],
   override def declareExchange(channel: Channel, exchangeConfig: DeclarationExchangeConfig): Stream[IO, Unit] =
     Stream.eval(IO(exchanges += exchangeConfig.exchangeName) *> IO.unit)
 
+  override def declareExchangeNoWait(channel: Channel, exchangeConfig: DeclarationExchangeConfig): Stream[IO, Unit] =
+    Stream.eval(IO(exchanges += exchangeConfig.exchangeName) *> IO.unit)
+
   override def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): Stream[IO, Unit] =
     Stream.eval(IO(exchanges += exchangeName) *> IO.unit)
 

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
@@ -131,6 +131,9 @@ class AMQPClientInMemory(ref: Ref[IO, AMQPInternals[IO]],
   override def declareExchange(channel: Channel, exchangeConfig: DeclarationExchangeConfig): Stream[IO, Unit] =
     Stream.eval(IO(exchanges += exchangeConfig.exchangeName) *> IO.unit)
 
+  override def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): Stream[IO, Unit] =
+    Stream.eval(IO(exchanges += exchangeName) *> IO.unit)
+
   override def declareQueue(channel: Channel, queueConfig: DeclarationQueueConfig): Stream[IO, Unit] =
     Stream.eval(IO(queues += queueConfig.queueName) *> IO.unit)
 

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -129,7 +129,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
     }
   }
 
-  it should "create a connection and a passive" in StreamAssertion(TestFs2Rabbit(config)) { interpreter =>
+  it should "create a connection and a passive queue" in StreamAssertion(TestFs2Rabbit(config)) { interpreter =>
     import interpreter._
     createConnectionChannel flatMap { implicit channel =>
       for {
@@ -145,6 +145,17 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
       for {
         _ <- declareQueue(DeclarationQueueConfig.default(queueName))
         _ <- declareExchange(exchangeName, ExchangeType.Topic)
+      } yield ()
+    }
+  }
+
+  it should "create a connection and declare an exchange" in StreamAssertion(TestFs2Rabbit(config)) { interpreter =>
+    import interpreter._
+    createConnectionChannel flatMap { implicit channel =>
+      for {
+        _ <- declareQueue(DeclarationQueueConfig.default(queueName))
+        _ <- declareExchangePassive(exchangeName)
+        _ <- bindQueue(queueName, exchangeName, RoutingKey("some.routing.key"))
       } yield ()
     }
   }

--- a/site/src/main/tut/exchanges.md
+++ b/site/src/main/tut/exchanges.md
@@ -11,6 +11,7 @@ Before getting into the `Consumers` section there are two things you need to kno
 ### Declaring a Exchange
 
 Declaring a `Exchange` means that if already exists it's going to get a reference to it or otherwise it will create it.
+If the `Exchange` does already exist, but has different properties (type, internal, ...), it is an error.
 
 ```tut:book:silent
 import cats.effect.IO
@@ -25,6 +26,23 @@ def exchanges(implicit F: Fs2Rabbit[IO]) = F.createConnectionChannel flatMap { i
   for {
     _ <- F.declareExchange(x1, ExchangeType.Topic)
     _ <- F.declareExchange(x2, ExchangeType.FanOut)
+  } yield ()
+}
+```
+
+An `Exchange` can be declared passively, meaning that the `Exchange` is required to exist, whatever its properties.
+
+```tut:book:silent
+import cats.effect.IO
+import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
+import com.github.gvolpe.fs2rabbit.model._
+import fs2._
+
+val x = ExchangeName("x")
+
+def exchanges(implicit F: Fs2Rabbit[IO]) = F.createConnectionChannel flatMap { implicit channel =>
+  for {
+    _ <- F.declareExchangePassive(x)
   } yield ()
 }
 ```


### PR DESCRIPTION
This adds the two missing exchange declarations:
- exchangeDeclarePassive
- exchangeDeclareNoWait

I added the related documentation for passive. For no-wait, I did not add any doc about it (queues no-wait are not documented either). If necessary, I will add it, but I never use it personally.

This should help closing #9.