### PR TITLE
[Refactor] - scalacOptions, main interpreter, typeclass constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,6 @@ And this one if you would like to have Json support:
 libraryDependencies += "com.github.gvolpe" %% "fs2-rabbit-circe" % Version
 ```
 
-`fs2-rabbit` has the following dependencies and it's cross compiled to Scala `2.11.12` and `2.12.6`:
-
-| Dependency  | Version    |
-| ----------- |:----------:|
-| cats        | 1.3.1      |
-| cats-effect | 1.0.0      |
-| fs2         | 1.0.0-RC1  |
-| circe       | 0.10.0     |
-| amqp-client | 4.6.0      |
-
 ## Usage Guide
 
 Check the [official guide](https://gvolpe.github.io/fs2-rabbit/guide.html) for updated compiling examples.

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,56 @@ promptTheme := PromptTheme(List(
   text(_ => "fs2-rabbit", fg(64)).padRight(" λ ")
  ))
 
+lazy val commonScalacOptions = Seq(
+  "-deprecation",
+  "-encoding",
+  "UTF-8",
+  "-feature",
+  "-language:existentials",
+  "-language:higherKinds",
+  "-language:implicitConversions",
+  "-language:experimental.macros",
+  "-unchecked",
+  "-Xfatal-warnings",
+  "-Xlint",
+  "-Yno-adapted-args",
+  "-Ywarn-dead-code",
+  "-Ywarn-value-discard",
+  "-Xfuture",
+  "-Xlog-reflective-calls",
+  "-Ywarn-inaccessible",
+  "-Ypatmat-exhaust-depth",
+  "20",
+  "-Ydelambdafy:method",
+  "-Xmax-classfile-name",
+  "100"
+)
+
+
+lazy val warnUnusedImport = Seq(
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 10)) =>
+        Seq()
+      case Some((2, n)) if n >= 11 =>
+        Seq("-Ywarn-unused-import")
+    }
+  },
+  scalacOptions in (Compile, console) ~= { _.filterNot(Seq("-Xlint", "-Ywarn-unused-import").contains) },
+  scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
+)
+
+lazy val partialUnification = Seq(
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, n)) if n >= 12 =>
+        Seq("-Ypartial-unification")
+      case _ =>
+        Seq()
+    }
+  }
+)
+
 val commonSettings = Seq(
   organizationName := "Fs2 Rabbit",
   startYear := Some(2017),
@@ -32,16 +82,7 @@ val commonSettings = Seq(
     Libraries.scalaCheck
   ),
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
-  scalacOptions ++= Seq(
-    "-Xmax-classfile-name", "80",
-    "-deprecation",
-    "-encoding",
-    "UTF-8",
-    "-feature",
-    "-Ypartial-unification",
-    "-language:existentials",
-    "-language:higherKinds"
-  ),
+  scalacOptions ++= commonScalacOptions,
   scalafmtOnCompile := true,
   coverageExcludedPackages := "com\\.github\\.gvolpe\\.fs2rabbit\\.examples.*;com\\.github\\.gvolpe\\.fs2rabbit\\.util.*;.*QueueName*;.*RoutingKey*;.*ExchangeName*;.*DeliveryTag*;.*AMQPClientStream*;.*ConnectionStream*;",
   publishTo := {
@@ -62,7 +103,7 @@ val commonSettings = Seq(
           <url>http://github.com/gvolpe</url>
         </developer>
       </developers>
-)
+) ++ warnUnusedImport ++ partialUnification
 
 val CoreDependencies: Seq[ModuleID] = Seq(
   Libraries.logback % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,7 @@ val commonSettings = Seq(
   homepage := Some(url("https://github.com/gvolpe/fs2-rabbit")),
   libraryDependencies ++= Seq(
     compilerPlugin(Libraries.kindProjector),
+    compilerPlugin(Libraries.betterMonadicFor),
     Libraries.amqpClient,
     Libraries.catsEffect,
     Libraries.fs2Core,

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -98,17 +98,19 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
   override def bindQueue(channel: Channel,
                          queueName: QueueName,
                          exchangeName: ExchangeName,
-                         routingKey: RoutingKey): Stream[F, Unit] = SE.evalF {
-    channel.queueBind(queueName.value, exchangeName.value, routingKey.value)
-  }
+                         routingKey: RoutingKey): Stream[F, Unit] =
+    SE.evalF {
+      channel.queueBind(queueName.value, exchangeName.value, routingKey.value)
+    }.drain
 
   override def bindQueue(channel: Channel,
                          queueName: QueueName,
                          exchangeName: ExchangeName,
                          routingKey: RoutingKey,
-                         args: QueueBindingArgs): Stream[F, Unit] = SE.evalF {
-    channel.queueBind(queueName.value, exchangeName.value, routingKey.value, args.value)
-  }
+                         args: QueueBindingArgs): Stream[F, Unit] =
+    SE.evalF {
+      channel.queueBind(queueName.value, exchangeName.value, routingKey.value, args.value)
+    }.drain
 
   override def bindQueueNoWait(channel: Channel,
                                queueName: QueueName,
@@ -121,25 +123,28 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
   override def unbindQueue(channel: Channel,
                            queueName: QueueName,
                            exchangeName: ExchangeName,
-                           routingKey: RoutingKey): Stream[F, Unit] = SE.evalF {
-    unbindQueue(channel, queueName, exchangeName, routingKey, QueueUnbindArgs(Map.empty))
-  }
+                           routingKey: RoutingKey): Stream[F, Unit] =
+    SE.evalF {
+      unbindQueue(channel, queueName, exchangeName, routingKey, QueueUnbindArgs(Map.empty))
+    }.drain
 
   override def unbindQueue(channel: Channel,
                            queueName: QueueName,
                            exchangeName: ExchangeName,
                            routingKey: RoutingKey,
-                           args: QueueUnbindArgs): Stream[F, Unit] = SE.evalF {
-    channel.queueUnbind(queueName.value, exchangeName.value, routingKey.value, args.value)
-  }
+                           args: QueueUnbindArgs): Stream[F, Unit] =
+    SE.evalF {
+      channel.queueUnbind(queueName.value, exchangeName.value, routingKey.value, args.value)
+    }.drain
 
   override def bindExchange(channel: Channel,
                             destination: ExchangeName,
                             source: ExchangeName,
                             routingKey: RoutingKey,
-                            args: ExchangeBindingArgs): Stream[F, Unit] = SE.evalF {
-    channel.exchangeBind(destination.value, source.value, routingKey.value, args.value)
-  }
+                            args: ExchangeBindingArgs): Stream[F, Unit] =
+    SE.evalF {
+      channel.exchangeBind(destination.value, source.value, routingKey.value, args.value)
+    }.drain
 
   override def bindExchangeNoWait(channel: Channel,
                                   destination: ExchangeName,
@@ -153,20 +158,22 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
                               destination: ExchangeName,
                               source: ExchangeName,
                               routingKey: RoutingKey,
-                              args: ExchangeUnbindArgs): Stream[F, Unit] = SE.evalF {
-    channel.exchangeUnbind(destination.value, source.value, routingKey.value, args.value)
-  }
+                              args: ExchangeUnbindArgs): Stream[F, Unit] =
+    SE.evalF {
+      channel.exchangeUnbind(destination.value, source.value, routingKey.value, args.value)
+    }.drain
 
-  override def declareExchange(channel: Channel, config: DeclarationExchangeConfig): Stream[F, Unit] = SE.evalF {
-    channel.exchangeDeclare(
-      config.exchangeName.value,
-      config.exchangeType.toString.toLowerCase,
-      config.durable.isTrue,
-      config.autoDelete.isTrue,
-      config.internal.isTrue,
-      config.arguments
-    )
-  }
+  override def declareExchange(channel: Channel, config: DeclarationExchangeConfig): Stream[F, Unit] =
+    SE.evalF {
+      channel.exchangeDeclare(
+        config.exchangeName.value,
+        config.exchangeType.toString.toLowerCase,
+        config.durable.isTrue,
+        config.autoDelete.isTrue,
+        config.internal.isTrue,
+        config.arguments
+      )
+    }.drain
 
   override def declareExchangeNoWait(channel: Channel, config: DeclarationExchangeConfig): Stream[F, Unit] =
     SE.evalF {
@@ -180,19 +187,21 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       )
     }
 
-  override def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): Stream[F, Unit] = SE.evalF {
-    channel.exchangeDeclarePassive(exchangeName.value)
-  }
+  override def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): Stream[F, Unit] =
+    SE.evalF {
+      channel.exchangeDeclarePassive(exchangeName.value)
+    }.drain
 
-  override def declareQueue(channel: Channel, config: DeclarationQueueConfig): Stream[F, Unit] = SE.evalF {
-    channel.queueDeclare(
-      config.queueName.value,
-      config.durable.isTrue,
-      config.exclusive.isTrue,
-      config.autoDelete.isTrue,
-      config.arguments
-    )
-  }
+  override def declareQueue(channel: Channel, config: DeclarationQueueConfig): Stream[F, Unit] =
+    SE.evalF {
+      channel.queueDeclare(
+        config.queueName.value,
+        config.durable.isTrue,
+        config.exclusive.isTrue,
+        config.autoDelete.isTrue,
+        config.arguments
+      )
+    }.drain
 
   override def declareQueueNoWait(channel: Channel, config: DeclarationQueueConfig): Stream[F, Unit] =
     SE.evalF {
@@ -205,21 +214,25 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       )
     }
 
-  override def declareQueuePassive(channel: Channel, queueName: QueueName): Stream[F, Unit] = SE.evalF {
-    channel.queueDeclarePassive(queueName.value)
-  }
+  override def declareQueuePassive(channel: Channel, queueName: QueueName): Stream[F, Unit] =
+    SE.evalF {
+      channel.queueDeclarePassive(queueName.value)
+    }.drain
 
-  override def deleteQueue(channel: Channel, config: DeletionQueueConfig): Stream[F, Unit] = SE.evalF {
-    channel.queueDelete(config.queueName.value, config.ifUnused.isTrue, config.ifEmpty.isTrue)
-  }
+  override def deleteQueue(channel: Channel, config: DeletionQueueConfig): Stream[F, Unit] =
+    SE.evalF {
+      channel.queueDelete(config.queueName.value, config.ifUnused.isTrue, config.ifEmpty.isTrue)
+    }.drain
 
-  override def deleteQueueNoWait(channel: Channel, config: DeletionQueueConfig): Stream[F, Unit] = SE.evalF {
-    channel.queueDeleteNoWait(config.queueName.value, config.ifUnused.isTrue, config.ifEmpty.isTrue)
-  }
+  override def deleteQueueNoWait(channel: Channel, config: DeletionQueueConfig): Stream[F, Unit] =
+    SE.evalF {
+      channel.queueDeleteNoWait(config.queueName.value, config.ifUnused.isTrue, config.ifEmpty.isTrue)
+    }.drain
 
-  override def deleteExchange(channel: Channel, config: deletion.DeletionExchangeConfig): Stream[F, Unit] = SE.evalF {
-    channel.exchangeDelete(config.exchangeName.value, config.ifUnused.isTrue)
-  }
+  override def deleteExchange(channel: Channel, config: deletion.DeletionExchangeConfig): Stream[F, Unit] =
+    SE.evalF {
+      channel.exchangeDelete(config.exchangeName.value, config.ifUnused.isTrue)
+    }.drain
 
   override def deleteExchangeNoWait(channel: Channel, config: deletion.DeletionExchangeConfig): Stream[F, Unit] =
     SE.evalF {

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -60,16 +60,16 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       }
     )
 
-  override def basicAck(channel: Channel, tag: DeliveryTag, multiple: Boolean): Stream[F, Unit] = SE.evalF {
+  override def basicAck(channel: Channel, tag: DeliveryTag, multiple: Boolean): Stream[F, Unit] = SE.evalDiscard {
     channel.basicAck(tag.value, multiple)
   }
 
   override def basicNack(channel: Channel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.basicNack(tag.value, multiple, requeue)
     }
 
-  override def basicQos(channel: Channel, basicQos: BasicQos): Stream[F, Unit] = SE.evalF {
+  override def basicQos(channel: Channel, basicQos: BasicQos): Stream[F, Unit] = SE.evalDiscard {
     channel.basicQos(basicQos.prefetchSize, basicQos.prefetchCount, basicQos.global)
   }
 
@@ -88,7 +88,7 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
   override def basicPublish(channel: Channel,
                             exchangeName: ExchangeName,
                             routingKey: RoutingKey,
-                            msg: AmqpMessage[String]): Stream[F, Unit] = SE.evalF {
+                            msg: AmqpMessage[String]): Stream[F, Unit] = SE.evalDiscard {
     channel.basicPublish(exchangeName.value,
                          routingKey.value,
                          msg.properties.asBasicProps,
@@ -99,24 +99,24 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
                          queueName: QueueName,
                          exchangeName: ExchangeName,
                          routingKey: RoutingKey): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.queueBind(queueName.value, exchangeName.value, routingKey.value)
-    }.drain
+    }
 
   override def bindQueue(channel: Channel,
                          queueName: QueueName,
                          exchangeName: ExchangeName,
                          routingKey: RoutingKey,
                          args: QueueBindingArgs): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.queueBind(queueName.value, exchangeName.value, routingKey.value, args.value)
-    }.drain
+    }
 
   override def bindQueueNoWait(channel: Channel,
                                queueName: QueueName,
                                exchangeName: ExchangeName,
                                routingKey: RoutingKey,
-                               args: QueueBindingArgs): Stream[F, Unit] = SE.evalF {
+                               args: QueueBindingArgs): Stream[F, Unit] = SE.evalDiscard {
     channel.queueBindNoWait(queueName.value, exchangeName.value, routingKey.value, args.value)
   }
 
@@ -124,33 +124,33 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
                            queueName: QueueName,
                            exchangeName: ExchangeName,
                            routingKey: RoutingKey): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       unbindQueue(channel, queueName, exchangeName, routingKey, QueueUnbindArgs(Map.empty))
-    }.drain
+    }
 
   override def unbindQueue(channel: Channel,
                            queueName: QueueName,
                            exchangeName: ExchangeName,
                            routingKey: RoutingKey,
                            args: QueueUnbindArgs): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.queueUnbind(queueName.value, exchangeName.value, routingKey.value, args.value)
-    }.drain
+    }
 
   override def bindExchange(channel: Channel,
                             destination: ExchangeName,
                             source: ExchangeName,
                             routingKey: RoutingKey,
                             args: ExchangeBindingArgs): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.exchangeBind(destination.value, source.value, routingKey.value, args.value)
-    }.drain
+    }
 
   override def bindExchangeNoWait(channel: Channel,
                                   destination: ExchangeName,
                                   source: ExchangeName,
                                   routingKey: RoutingKey,
-                                  args: ExchangeBindingArgs): Stream[F, Unit] = SE.evalF {
+                                  args: ExchangeBindingArgs): Stream[F, Unit] = SE.evalDiscard {
     channel.exchangeBindNoWait(destination.value, source.value, routingKey.value, args.value)
   }
 
@@ -159,12 +159,12 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
                               source: ExchangeName,
                               routingKey: RoutingKey,
                               args: ExchangeUnbindArgs): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.exchangeUnbind(destination.value, source.value, routingKey.value, args.value)
-    }.drain
+    }
 
   override def declareExchange(channel: Channel, config: DeclarationExchangeConfig): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.exchangeDeclare(
         config.exchangeName.value,
         config.exchangeType.toString.toLowerCase,
@@ -173,10 +173,10 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
         config.internal.isTrue,
         config.arguments
       )
-    }.drain
+    }
 
   override def declareExchangeNoWait(channel: Channel, config: DeclarationExchangeConfig): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.exchangeDeclareNoWait(
         config.exchangeName.value,
         config.exchangeType.toString.toLowerCase,
@@ -188,12 +188,12 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
     }
 
   override def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.exchangeDeclarePassive(exchangeName.value)
-    }.drain
+    }
 
   override def declareQueue(channel: Channel, config: DeclarationQueueConfig): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.queueDeclare(
         config.queueName.value,
         config.durable.isTrue,
@@ -201,10 +201,10 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
         config.autoDelete.isTrue,
         config.arguments
       )
-    }.drain
+    }
 
   override def declareQueueNoWait(channel: Channel, config: DeclarationQueueConfig): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.queueDeclareNoWait(
         config.queueName.value,
         config.durable.isTrue,
@@ -215,27 +215,27 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
     }
 
   override def declareQueuePassive(channel: Channel, queueName: QueueName): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.queueDeclarePassive(queueName.value)
-    }.drain
+    }
 
   override def deleteQueue(channel: Channel, config: DeletionQueueConfig): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.queueDelete(config.queueName.value, config.ifUnused.isTrue, config.ifEmpty.isTrue)
-    }.drain
+    }
 
   override def deleteQueueNoWait(channel: Channel, config: DeletionQueueConfig): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.queueDeleteNoWait(config.queueName.value, config.ifUnused.isTrue, config.ifEmpty.isTrue)
-    }.drain
+    }
 
   override def deleteExchange(channel: Channel, config: deletion.DeletionExchangeConfig): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.exchangeDelete(config.exchangeName.value, config.ifUnused.isTrue)
-    }.drain
+    }
 
   override def deleteExchangeNoWait(channel: Channel, config: deletion.DeletionExchangeConfig): Stream[F, Unit] =
-    SE.evalF {
+    SE.evalDiscard {
       channel.exchangeDeleteNoWait(config.exchangeName.value, config.ifUnused.isTrue)
     }
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStream.scala
@@ -22,13 +22,12 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import com.github.gvolpe.fs2rabbit.algebra.Connection
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
-import com.github.gvolpe.fs2rabbit.util.{Log, StreamEval}
 import com.github.gvolpe.fs2rabbit.model.{AMQPChannel, RabbitChannel}
+import com.github.gvolpe.fs2rabbit.util.Log
 import com.rabbitmq.client.{ConnectionFactory, Connection => RabbitMQConnection}
 import fs2.Stream
 
-class ConnectionStream[F[_]](config: Fs2RabbitConfig)(implicit F: Sync[F], L: Log[F], SE: StreamEval[F])
-    extends Connection[Stream[F, ?]] {
+class ConnectionStream[F[_]](config: Fs2RabbitConfig)(implicit F: Sync[F], L: Log[F]) extends Connection[Stream[F, ?]] {
 
   private[fs2rabbit] lazy val connFactory: F[ConnectionFactory] =
     F.delay {
@@ -64,6 +63,6 @@ class ConnectionStream[F[_]](config: Fs2RabbitConfig)(implicit F: Sync[F], L: Lo
             F.delay { if (channel.isOpen) channel.close() } *> F.delay { if (conn.isOpen) conn.close() }
         case (_, _) => F.raiseError[Unit](new Exception("Unreachable"))
       }
-      .flatMap { case (_, channel) => SE.pure[AMQPChannel](channel) }
+      .map { case (_, channel) => channel }
 
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -17,7 +17,6 @@
 package com.github.gvolpe.fs2rabbit.interpreter
 
 import cats.effect.{Concurrent, ConcurrentEffect}
-import cats.syntax.applicative._
 import com.github.gvolpe.fs2rabbit.algebra.{AMQPClient, Acker, Connection, Consumer}
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.config.declaration.{DeclarationExchangeConfig, DeclarationQueueConfig}
@@ -28,12 +27,12 @@ import fs2.Stream
 
 // $COVERAGE-OFF$
 object Fs2Rabbit {
-  def apply[F[_]: ConcurrentEffect](config: Fs2RabbitConfig): F[Fs2Rabbit[F]] = {
+  def apply[F[_]: ConcurrentEffect](config: Fs2RabbitConfig): Fs2Rabbit[F] = {
     val amqpClient = new AMQPClientStream[F]
     val connStream = new ConnectionStream[F](config)
     val acker      = new AckerProgram[F](config, amqpClient)
     val consumer   = new ConsumerProgram[F](amqpClient)
-    new Fs2Rabbit[F](config, connStream, amqpClient, acker, consumer).pure[F]
+    new Fs2Rabbit[F](config, connStream, amqpClient, acker, consumer)
   }
 }
 // $COVERAGE-ON$
@@ -101,7 +100,7 @@ class Fs2Rabbit[F[_]: Concurrent](config: Fs2RabbitConfig,
                          routingKey: RoutingKey,
                          args: ExchangeBindingArgs)(implicit channel: AMQPChannel): Stream[F, Unit] =
     amqpClient.bindExchangeNoWait(channel.value, destination, source, routingKey, args)
-  
+
   def unbindExchange(destination: ExchangeName, source: ExchangeName, routingKey: RoutingKey, args: ExchangeUnbindArgs)(
       implicit channel: AMQPChannel): Stream[F, Unit] =
     amqpClient.unbindExchange(channel.value, destination, source, routingKey, args)

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerProgram.scala
@@ -16,17 +16,14 @@
 
 package com.github.gvolpe.fs2rabbit.program
 
-import cats.Monad
 import com.github.gvolpe.fs2rabbit.algebra.{AMQPClient, Acker}
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.model.AckResult.{Ack, NAck}
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.util.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.{Sink, Stream}
 
-class AckerProgram[F[_]: Monad](config: Fs2RabbitConfig, AMQP: AMQPClient[Stream[F, ?], F])(implicit SE: StreamEval[F])
-    extends Acker[Stream[F, ?]] {
+class AckerProgram[F[_]](config: Fs2RabbitConfig, AMQP: AMQPClient[Stream[F, ?], F]) extends Acker[Stream[F, ?]] {
 
   def createAcker(channel: Channel): Sink[F, AckResult] =
     _.flatMap {

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/PublishingProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/PublishingProgram.scala
@@ -16,14 +16,13 @@
 
 package com.github.gvolpe.fs2rabbit.program
 
-import cats.Monad
 import com.github.gvolpe.fs2rabbit.algebra.{AMQPClient, Publishing}
 import com.github.gvolpe.fs2rabbit.model.{ExchangeName, RoutingKey, StreamPublisher}
 import com.github.gvolpe.fs2rabbit.util.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.Stream
 
-class PublishingProgram[F[_]: Monad](AMQP: AMQPClient[Stream[F, ?], F])(implicit SE: StreamEval[F])
+class PublishingProgram[F[_]](AMQP: AMQPClient[Stream[F, ?], F])(implicit SE: StreamEval[F])
     extends Publishing[Stream[F, ?]] {
 
   override def createPublisher(channel: Channel,

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStream.scala
@@ -37,7 +37,7 @@ import scala.util.control.NonFatal
   * */
 object ResilientStream {
 
-  def run[F[_]: Sync: Timer: Log](program: Stream[F, Unit], retry: FiniteDuration = 5.seconds): F[Unit] =
+  def run[F[_]: Log: Sync: Timer](program: Stream[F, Unit], retry: FiniteDuration = 5.seconds): F[Unit] =
     loop(program, retry, 1).compile.drain
 
   private def loop[F[_]: Log: Sync: Timer](program: Stream[F, Unit],

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/Log.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/Log.scala
@@ -27,6 +27,8 @@ trait Log[F[_]] {
 object Log {
   private[fs2rabbit] val logger = LoggerFactory.getLogger(this.getClass)
 
+  def apply[F[_]](implicit ev: Log[F]): Log[F] = ev
+
   implicit def syncLogInstance[F[_]](implicit F: Sync[F]): Log[F] =
     new Log[F] {
       override def error(error: Throwable): F[Unit] = F.delay(logger.error(error.getMessage, error))

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/StreamEval.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/util/StreamEval.scala
@@ -28,13 +28,13 @@ trait StreamEval[F[_]] {
 
 object StreamEval {
 
-  implicit def syncStreamEvalInstance[F[_]](implicit F: Sync[F]): StreamEval[F] =
+  implicit def syncStreamEvalInstance[F[_]: Sync]: StreamEval[F] =
     new StreamEval[F] {
       override def pure[A](body: A): Stream[F, A] =
         Stream(body).covary[F]
 
       override def evalF[A](body: => A): Stream[F, A] =
-        Stream.eval[F, A](F.delay(body))
+        Stream.eval[F, A](Sync[F].delay(body))
 
       override def liftSink[A](f: A => F[Unit]): Sink[F, A] =
         liftPipe[A, Unit](f)

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
@@ -134,13 +134,12 @@ class AMQPClientInMemory(ref: Ref[IO, AMQPInternals[IO]],
                             routingKey: model.RoutingKey,
                             args: model.ExchangeBindingArgs): Stream[IO, Unit] = Stream.eval(IO.unit)
 
-
   override def bindExchangeNoWait(channel: Channel,
                                   destination: ExchangeName,
                                   source: ExchangeName,
                                   routingKey: RoutingKey,
                                   args: ExchangeBindingArgs): Stream[IO, Unit] = Stream.eval(IO.unit)
-      
+
   override def unbindExchange(channel: Channel,
                               destination: ExchangeName,
                               source: ExchangeName,

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AckerConsumerDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AckerConsumerDemo.scala
@@ -17,36 +17,32 @@
 package com.github.gvolpe.fs2rabbit.examples
 
 import cats.effect.{Concurrent, Timer}
+import cats.syntax.functor._
 import com.github.gvolpe.fs2rabbit.config.declaration.DeclarationQueueConfig
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
 import com.github.gvolpe.fs2rabbit.json.Fs2JsonEncoder
 import com.github.gvolpe.fs2rabbit.model.AckResult.Ack
 import com.github.gvolpe.fs2rabbit.model.AmqpHeaderVal.{LongVal, StringVal}
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.util.StreamEval
 import fs2.{Pipe, Stream}
 
-class AckerConsumerDemo[F[_]: Concurrent: Timer](implicit F: Fs2Rabbit[F], SE: StreamEval[F]) {
+class AckerConsumerDemo[F[_]: Timer](implicit F: Concurrent[F], R: Fs2Rabbit[F]) {
 
   private val queueName    = QueueName("testQ")
   private val exchangeName = ExchangeName("testEX")
   private val routingKey   = RoutingKey("testRK")
 
-  def logPipe: Pipe[F, AmqpEnvelope, AckResult] = { streamMsg =>
-    for {
-      amqpMsg <- streamMsg
-      _       <- SE.evalF[Unit](println(s"Consumed: $amqpMsg"))
-    } yield Ack(amqpMsg.deliveryTag)
+  def logPipe: Pipe[F, AmqpEnvelope, AckResult] = _.evalMap { amqpMsg =>
+    F.delay(println(s"Consumed: $amqpMsg")).as(Ack(amqpMsg.deliveryTag))
   }
 
-  val program: Stream[F, Unit] = F.createConnectionChannel flatMap { implicit channel =>
+  val program: Stream[F, Unit] = R.createConnectionChannel.flatMap { implicit channel =>
     for {
-      _                 <- F.declareQueue(DeclarationQueueConfig.default(queueName))
-      _                 <- F.declareExchange(exchangeName, ExchangeType.Topic)
-      _                 <- F.bindQueue(queueName, exchangeName, routingKey)
-      ackerConsumer     <- F.createAckerConsumer(queueName)
-      (acker, consumer) = ackerConsumer
-      publisher         <- F.createPublisher(exchangeName, routingKey)
+      _                 <- R.declareQueue(DeclarationQueueConfig.default(queueName))
+      _                 <- R.declareExchange(exchangeName, ExchangeType.Topic)
+      _                 <- R.bindQueue(queueName, exchangeName, routingKey)
+      (acker, consumer) <- R.createAckerConsumer(queueName)
+      publisher         <- R.createPublisher(exchangeName, routingKey)
       result            <- new Flow(consumer, acker, logPipe, publisher).flow
     } yield result
   }
@@ -72,9 +68,9 @@ class Flow[F[_]: Concurrent](consumer: StreamConsumer[F],
 
   val flow: Stream[F, Unit] =
     Stream(
-      Stream(simpleMessage).covary[F] to publisher,
-      Stream(classMessage).covary[F] through jsonEncode[Person] to publisher,
-      consumer through logger to acker
+      Stream(simpleMessage).covary[F].to(publisher),
+      Stream(classMessage).covary[F].through(jsonEncode[Person]).to(publisher),
+      consumer.through(logger).to(acker)
     ).parJoin(3)
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
@@ -40,10 +40,11 @@ object IOAckerConsumer extends IOApp {
     requeueOnNack = false
   )
 
+  implicit val fs2Rabbit: Fs2Rabbit[IO] = Fs2Rabbit[IO](config)
+
   override def run(args: List[String]): IO[ExitCode] =
-    Fs2Rabbit[IO](config)
-      .flatMap { implicit interpreter =>
-        ResilientStream.run(new AckerConsumerDemo[IO]().program)
-      }
+    ResilientStream
+      .run(new AckerConsumerDemo[IO]().program)
       .as(ExitCode.Success)
+
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
@@ -22,11 +22,7 @@ import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
 import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 
-import scala.concurrent.ExecutionContext
-
 object IOAckerConsumer extends IOApp {
-
-  implicit val appS: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   private val config: Fs2RabbitConfig = Fs2RabbitConfig(
     virtualHost = "/",

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -42,11 +42,11 @@ object MonixAutoAckConsumer extends IOApp {
     requeueOnNack = false
   )
 
+  implicit val fs2Rabbit: Fs2Rabbit[Task] = Fs2Rabbit[Task](config)
+
   override def run(args: List[String]): IO[ExitCode] =
-    Fs2Rabbit[Task](config)
-      .flatMap { implicit interpreter =>
-        ResilientStream.run(new AutoAckConsumerDemo[Task].program)
-      }
+    ResilientStream
+      .run(new AutoAckConsumerDemo[Task].program)
       .toIO
       .as(ExitCode.Success)
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -24,11 +24,7 @@ import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
-import scala.concurrent.ExecutionContext
-
 object MonixAutoAckConsumer extends IOApp {
-
-  implicit val appS: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   private val config: Fs2RabbitConfig = Fs2RabbitConfig(
     virtualHost = "/",

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
@@ -16,8 +16,9 @@
 
 package com.github.gvolpe.fs2rabbit.json
 
-import com.github.gvolpe.fs2rabbit.util.{Log, StreamEval}
+import cats.effect.Sync
 import com.github.gvolpe.fs2rabbit.model.{AmqpEnvelope, DeliveryTag}
+import com.github.gvolpe.fs2rabbit.util.Log
 import fs2.{Pipe, Stream}
 import io.circe.parser.decode
 import io.circe.{Decoder, Error}
@@ -26,7 +27,7 @@ import io.circe.{Decoder, Error}
   * Stream-based Json Decoder that exposes only one method as a streaming transformation
   * using [[fs2.Pipe]] and depends on the Circe library.
   * */
-class Fs2JsonDecoder[F[_]](implicit L: Log[F], SE: StreamEval[F]) {
+class Fs2JsonDecoder[F[_]: Log: Sync] {
 
   /**
     * It tries to decode an [[AmqpEnvelope.payload]] into a case class determined by the parameter [A].
@@ -46,12 +47,11 @@ class Fs2JsonDecoder[F[_]](implicit L: Log[F], SE: StreamEval[F]) {
     *
     * The result will be a tuple ([[Either]] of [[Error]] and [[A]], [[DeliveryTag]])
     * */
-  def jsonDecode[A: Decoder]: Pipe[F, AmqpEnvelope, (Either[Error, A], DeliveryTag)] =
-    streamMsg =>
-      for {
-        amqpMsg <- streamMsg
-        parsed  <- SE.evalF[Either[Error, A]](decode[A](amqpMsg.payload))
-        _       <- Stream.eval(L.info(s"Parsed: $parsed"))
-      } yield (parsed, amqpMsg.deliveryTag)
+  def jsonDecode[A: Decoder]: Pipe[F, AmqpEnvelope, (Either[Error, A], DeliveryTag)] = _.flatMap { amqpMsg =>
+    Stream
+      .eval(Sync[F].delay(decode[A](amqpMsg.payload)))
+      .evalTap(p => Log[F].info(s"Parsed: $p"))
+      .map(p => (p, amqpMsg.deliveryTag))
+  }
 
 }

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
@@ -16,7 +16,6 @@
 
 package com.github.gvolpe.fs2rabbit.json
 
-import cats.effect.Sync
 import com.github.gvolpe.fs2rabbit.util.{Log, StreamEval}
 import com.github.gvolpe.fs2rabbit.model.{AmqpEnvelope, DeliveryTag}
 import fs2.{Pipe, Stream}

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
@@ -49,11 +49,8 @@ class Fs2JsonEncoder[F[_]](printer: Printer = Printer.noSpaces)(implicit SE: Str
     *
     * The result will be an [[AmqpMessage]] of type [[String]]
     * */
-  def jsonEncode[A: Encoder]: Pipe[F, AmqpMessage[A], AmqpMessage[String]] =
-    streamMsg =>
-      for {
-        amqpMsg <- streamMsg
-        json    <- SE.evalF[String](amqpMsg.payload.asJson.pretty(printer))
-      } yield AmqpMessage(json, amqpMsg.properties)
+  def jsonEncode[A: Encoder]: Pipe[F, AmqpMessage[A], AmqpMessage[String]] = _.flatMap { amqpMsg =>
+    SE.evalF[String](amqpMsg.payload.asJson.pretty(printer)).map(AmqpMessage(_, amqpMsg.properties))
+  }
 
 }

--- a/json-circe/src/test/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoderSpec.scala
+++ b/json-circe/src/test/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoderSpec.scala
@@ -61,20 +61,23 @@ class Fs2JsonDecoderSpec extends Fs2JsonDecoderFixture with FlatSpecLike with Ma
 
 }
 
+object Message {
+  sealed trait Message               extends Product with Serializable
+  final case class One(one: String)  extends Message
+  final case class Two(two: String)  extends Message
+  final case class Three(three: Int) extends Message
+}
+
 trait Fs2JsonDecoderFixture extends PropertyChecks {
 
   import io.circe.generic.auto._
+  import Message._
 
   val fs2JsonDecoder = new Fs2JsonDecoder[IO]
   import fs2JsonDecoder.jsonDecode
 
   case class Address(number: Int, streetName: String)
   case class Person(name: String, address: Address)
-
-  sealed trait Message               extends Product with Serializable
-  final case class One(one: String)  extends Message
-  final case class Two(two: String)  extends Message
-  final case class Three(three: Int) extends Message
 
   implicit def msgDecoder[A >: Message]: Decoder[A] =
     List[Decoder[A]](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,9 @@ object Dependencies {
     val amqpClient = "5.4.2"
     val logback    = "1.1.3"
     val monix      = "3.0.0-RC1"
-    val kindProjector = "0.9.8"
+
+    val kindProjector    = "0.9.8"
+    val betterMonadicFor = "0.3.0-M2"
 
     val scalaTest  = "3.0.5"
     val scalaCheck = "1.13.5"
@@ -21,7 +23,8 @@ object Dependencies {
     lazy val fs2Core    = "co.fs2"        %% "fs2-core"    % Versions.fs2
 
     // Compiler
-    lazy val kindProjector = "org.spire-math" % "kind-projector" % Versions.kindProjector cross CrossVersion.binary
+    lazy val kindProjector    = "org.spire-math" % "kind-projector" % Versions.kindProjector cross CrossVersion.binary
+    lazy val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % Versions.betterMonadicFor
 
     // Examples
     lazy val monix   = "io.monix"       %% "monix"          % Versions.monix

--- a/site/src/main/tut/examples/sample-acker.md
+++ b/site/src/main/tut/examples/sample-acker.md
@@ -86,8 +86,6 @@ import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 
 object IOAckerConsumer extends IOApp {
 
-  implicit val ec = scala.concurrent.ExecutionContext.global
-
   private val config: Fs2RabbitConfig = Fs2RabbitConfig(virtualHost = "/",
                                                         host = "127.0.0.1",
                                                         username = Some("guest"),
@@ -98,9 +96,10 @@ object IOAckerConsumer extends IOApp {
                                                         connectionTimeout = 3,
                                                         requeueOnNack = false)
 
+  implicit val fs2rabbit: Fs2Rabbit[IO] = Fs2Rabbit[IO](config)
+
   override def run(args: List[String]): IO[ExitCode] =
-    Fs2Rabbit[IO](config).flatMap { implicit interpreter =>
-      ResilientStream.run(new AckerConsumerDemo[IO]().program)
-    }.as(ExitCode.Success)
+    ResilientStream.run(new AckerConsumerDemo[IO]().program)
+      .as(ExitCode.Success)
 }
 ```

--- a/site/src/main/tut/examples/sample-autoack.md
+++ b/site/src/main/tut/examples/sample-autoack.md
@@ -87,8 +87,6 @@ import monix.execution.Scheduler.Implicits.global
 
 object MonixAutoAckConsumer extends IOApp {
 
-  implicit val ec = scala.concurrent.ExecutionContext.global
-
   private val config: Fs2RabbitConfig = Fs2RabbitConfig(virtualHost = "/",
                                                         host = "127.0.0.1",
                                                         username = Some("guest"),
@@ -99,9 +97,10 @@ object MonixAutoAckConsumer extends IOApp {
                                                         connectionTimeout = 3,
                                                         requeueOnNack = false)
 
+  implicit val fs2rabbit: Fs2Rabbit[Task] = Fs2Rabbit[Task](config)
+
   override def run(args: List[String]): IO[ExitCode] =
-    Fs2Rabbit[Task](config).flatMap { implicit interpreter =>
-      ResilientStream.run(new AutoAckConsumerDemo[Task].program)
-    }.toIO.as(ExitCode.Success)
+    ResilientStream.run(new AutoAckConsumerDemo[Task].program)
+     .toIO.as(ExitCode.Success)
 }
 ```

--- a/site/src/main/tut/interpreter.md
+++ b/site/src/main/tut/interpreter.md
@@ -6,7 +6,7 @@ number: 2
 
 # Fs2 Rabbit Interpreter
 
-It is the main interpreter that will be interacting with `RabbitMQ`, a.k.a. the client. All it needs are a `Fs2RabbitConfig` and an implicit instance of `ConcurrentEffect[F]`.
+It is the main interpreter that will be interacting with `RabbitMQ`, a.k.a. the client. All it needs are a `Fs2RabbitConfig` and an implicit instance of `ConcurrentEffect[F]`. Its creation is side-effects free in latest versions (+1.0-RC2).
 
 ```tut:book:silent
 import cats.effect._
@@ -14,30 +14,42 @@ import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
 
 object Fs2Rabbit {
-  def apply[F[_]: ConcurrentEffect](config: Fs2RabbitConfig): F[Fs2Rabbit[F]] = ???
+  def apply[F[_]: ConcurrentEffect](config: Fs2RabbitConfig): Fs2Rabbit[F] = ???
 }
 ```
 
-The recommended way to create the interpreter is to call `apply` and then `flatMap` to access the inner instance and make it available as an implicit. For example:
-
-```tut:book:invisible
-import com.github.gvolpe.fs2rabbit.model._
-val config: Fs2RabbitConfig = null
-```
+The recommended way to create the interpreter is to call `apply` and make it available as an implicit. For example:
 
 ```tut:book:silent
+import cats.effect.{ExitCode, IOApp}
+import cats.syntax.functor._
+import com.github.gvolpe.fs2rabbit.model._
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
 import fs2._
 
-import scala.concurrent.ExecutionContext
+object Program {
+  def foo[F[_]](implicit R: Fs2Rabbit[F]): Stream[F, Unit] = ???
+}
 
-implicit val cs = IO.contextShift(ExecutionContext.global)
+class Demo extends IOApp {
 
-def yourProgram[F[_]](implicit R: Fs2Rabbit[F]): Stream[F, Unit] = ???
+  val config: Fs2RabbitConfig = Fs2RabbitConfig(
+    virtualHost = "/",
+    host = "127.0.0.1",
+    username = Some("guest"),
+    password = Some("guest"),
+    port = 5672,
+    ssl = false,
+    sslContext = None,
+    connectionTimeout = 3,
+    requeueOnNack = false
+  )
 
-Stream.eval(Fs2Rabbit[IO](config)).flatMap { implicit interpreter =>
-  yourProgram[IO]
+  implicit val fs2Rabbit: Fs2Rabbit[IO] = Fs2Rabbit[IO](config)
+
+  override def run(args: List[String]): IO[ExitCode] =
+    Program.foo[IO].compile.drain.as(ExitCode.Success)
+
 }
 ```
 
-Note that since the `apply` method returns `F[Fs2Rabbit[F]]` you need to evaluate it within a streaming context using `Stream.eval` to integrate it with `yourProgram` that has the type `Stream[F, Unit]`.


### PR DESCRIPTION
- Revisited `scalacOptions`
- Made creation of `Fs2Rabbit` non-effectful
- Relaxed typeclass constraints
- Added `better-monadic-for` plugin