### PR TITLE
[Version 2] - Generic AMQP envelope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,8 @@ val commonSettings = Seq(
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
   scalacOptions ++= commonScalacOptions,
   scalafmtOnCompile := true,
-  coverageExcludedPackages := "com\\.github\\.gvolpe\\.fs2rabbit\\.examples.*;com\\.github\\.gvolpe\\.fs2rabbit\\.util.*;.*QueueName*;.*RoutingKey*;.*ExchangeName*;.*DeliveryTag*;.*AMQPClientStream*;.*ConnectionStream*;",
+  coverageExcludedPackages :=
+  "com\\.github\\.gvolpe\\.fs2rabbit\\.examples.*;com\\.github\\.gvolpe\\.fs2rabbit\\.effects.*;.*QueueName*;.*RoutingKey*;.*ExchangeName*;.*DeliveryTag*;.*AMQPClientStream*;.*ConnectionStream*;",
   publishTo := {
     val sonatype = "https://oss.sonatype.org/"
     if (isSnapshot.value)

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val commonScalacOptions = Seq(
   "-language:higherKinds",
   "-language:implicitConversions",
   "-language:experimental.macros",
+  "-Ypartial-unification",
   "-unchecked",
   "-Xfatal-warnings",
   "-Xlint",
@@ -53,17 +54,6 @@ lazy val warnUnusedImport = Seq(
   },
   scalacOptions in (Compile, console) ~= { _.filterNot(Seq("-Xlint", "-Ywarn-unused-import").contains) },
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
-)
-
-lazy val partialUnification = Seq(
-  scalacOptions ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, n)) if n >= 12 =>
-        Seq("-Ypartial-unification")
-      case _ =>
-        Seq()
-    }
-  }
 )
 
 val commonSettings = Seq(
@@ -103,7 +93,7 @@ val commonSettings = Seq(
           <url>http://github.com/gvolpe</url>
         </developer>
       </developers>
-) ++ warnUnusedImport ++ partialUnification
+) ++ warnUnusedImport
 
 val CoreDependencies: Seq[ModuleID] = Seq(
   Libraries.logback % "test"

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
@@ -23,12 +23,12 @@ import com.github.gvolpe.fs2rabbit.model._
 import com.rabbitmq.client.Channel
 
 // format: off
-trait AMQPClient[F[_], G[_]] extends Binding[F] with Declaration[F] with Deletion[F] {
+trait AMQPClient[F[_], G[_], A] extends Binding[F] with Declaration[F] with Deletion[F] {
   def basicAck(channel: Channel, tag: DeliveryTag, multiple: Boolean): F[Unit]
   def basicNack(channel: Channel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit]
   def basicQos(channel: Channel, basicQos: BasicQos): F[Unit]
   def basicConsume(channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Arguments)
-                  (internals: AMQPInternals[G]): F[String]
+                  (internals: AMQPInternals[G, A]): F[String]
   def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[String]): F[Unit]
   def basicPublishWithFlag(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, flag: PublishingFlag, msg: AmqpMessage[String]): F[Unit]
   def addPublishingListener(channel: Channel, listener: PublishingListener[G]): F[Unit]

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
@@ -19,16 +19,17 @@ package com.github.gvolpe.fs2rabbit.algebra
 import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.config.declaration.{DeclarationExchangeConfig, DeclarationQueueConfig}
 import com.github.gvolpe.fs2rabbit.config.deletion.{DeletionExchangeConfig, DeletionQueueConfig}
+import com.github.gvolpe.fs2rabbit.effects.EnvelopeDecoder
 import com.github.gvolpe.fs2rabbit.model._
 import com.rabbitmq.client.Channel
 
 // format: off
-trait AMQPClient[F[_], G[_], A] extends Binding[F] with Declaration[F] with Deletion[F] {
+trait AMQPClient[F[_], G[_]] extends Binding[F] with Declaration[F] with Deletion[F] {
   def basicAck(channel: Channel, tag: DeliveryTag, multiple: Boolean): F[Unit]
   def basicNack(channel: Channel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit]
   def basicQos(channel: Channel, basicQos: BasicQos): F[Unit]
-  def basicConsume(channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Arguments)
-                  (internals: AMQPInternals[G, A]): F[String]
+  def basicConsume[A](channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Arguments)
+                  (internals: AMQPInternals[G, A])(implicit decoder: EnvelopeDecoder[G, A]): F[String]
   def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[String]): F[Unit]
   def basicPublishWithFlag(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, flag: PublishingFlag, msg: AmqpMessage[String]): F[Unit]
   def addPublishingListener(channel: Channel, listener: PublishingListener[G]): F[Unit]

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPInternals.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPInternals.scala
@@ -19,4 +19,4 @@ package com.github.gvolpe.fs2rabbit.algebra
 import com.github.gvolpe.fs2rabbit.model.AmqpEnvelope
 import fs2.concurrent.Queue
 
-case class AMQPInternals[F[_]](queue: Option[Queue[F, Either[Throwable, AmqpEnvelope]]])
+case class AMQPInternals[F[_], A](queue: Option[Queue[F, Either[Throwable, AmqpEnvelope[A]]]])

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consumer.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consumer.scala
@@ -17,12 +17,13 @@
 package com.github.gvolpe.fs2rabbit.algebra
 
 import com.github.gvolpe.fs2rabbit.arguments.Arguments
+import com.github.gvolpe.fs2rabbit.effects.EnvelopeDecoder
 import com.github.gvolpe.fs2rabbit.model.{AmqpEnvelope, BasicQos, QueueName}
 import com.rabbitmq.client.Channel
 
-trait Consumer[F[_], A] {
+trait Consumer[F[_], G[_]] {
 
-  def createConsumer(
+  def createConsumer[A](
       queueName: QueueName,
       channel: Channel,
       basicQos: BasicQos,
@@ -31,6 +32,6 @@ trait Consumer[F[_], A] {
       exclusive: Boolean = false,
       consumerTag: String = "",
       args: Arguments = Map.empty
-  ): F[AmqpEnvelope[A]]
+  )(implicit decoder: EnvelopeDecoder[G, A]): F[AmqpEnvelope[A]]
 
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consumer.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consumer.scala
@@ -20,7 +20,7 @@ import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.model.{AmqpEnvelope, BasicQos, QueueName}
 import com.rabbitmq.client.Channel
 
-trait Consumer[F[_]] {
+trait Consumer[F[_], A] {
 
   def createConsumer(
       queueName: QueueName,
@@ -31,6 +31,6 @@ trait Consumer[F[_]] {
       exclusive: Boolean = false,
       consumerTag: String = "",
       args: Arguments = Map.empty
-  ): F[AmqpEnvelope]
+  ): F[AmqpEnvelope[A]]
 
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
@@ -19,20 +19,20 @@ package com.github.gvolpe.fs2rabbit.algebra
 import com.github.gvolpe.fs2rabbit.model.{AckResult, AmqpEnvelope, BasicQos, ConsumerArgs, QueueName}
 import com.rabbitmq.client.Channel
 
-trait Consuming[F[_]] {
+trait Consuming[F[_], A] {
 
   def createAckerConsumer(
       channel: Channel,
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  ): F[(F[AckResult] => F[Unit], F[AmqpEnvelope])]
+  ): F[(F[AckResult] => F[Unit], F[AmqpEnvelope[A]])]
 
   def createAutoAckConsumer(
       channel: Channel,
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  ): F[F[AmqpEnvelope]]
+  ): F[F[AmqpEnvelope[A]]]
 
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
@@ -16,23 +16,24 @@
 
 package com.github.gvolpe.fs2rabbit.algebra
 
+import com.github.gvolpe.fs2rabbit.effects.EnvelopeDecoder
 import com.github.gvolpe.fs2rabbit.model.{AckResult, AmqpEnvelope, BasicQos, ConsumerArgs, QueueName}
 import com.rabbitmq.client.Channel
 
-trait Consuming[F[_], A] {
+trait Consuming[F[_], G[_]] {
 
-  def createAckerConsumer(
+  def createAckerConsumer[A](
       channel: Channel,
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  ): F[(F[AckResult] => F[Unit], F[AmqpEnvelope[A]])]
+  )(implicit decoder: EnvelopeDecoder[G, A]): F[(F[AckResult] => F[Unit], F[AmqpEnvelope[A]])]
 
-  def createAutoAckConsumer(
+  def createAutoAckConsumer[A](
       channel: Channel,
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  ): F[F[AmqpEnvelope[A]]]
+  )(implicit decoder: EnvelopeDecoder[G, A]): F[F[AmqpEnvelope[A]]]
 
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/BoolValue.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/BoolValue.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit.util
+package com.github.gvolpe.fs2rabbit.effects
 
 import com.github.gvolpe.fs2rabbit.config.declaration._
 import com.github.gvolpe.fs2rabbit.config.deletion.{Empty, IfEmptyCfg, IfUnusedCfg, Unused}

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoder.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoder.scala
@@ -16,6 +16,8 @@
 
 package com.github.gvolpe.fs2rabbit.effects
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import cats.ApplicativeError
 
 /**
@@ -32,6 +34,6 @@ object EnvelopeDecoder {
 
   implicit def utf8StringDecoder[F[_]](implicit F: ApplicativeError[F, Throwable]): EnvelopeDecoder[F, String] =
     new EnvelopeDecoder[F, String] {
-      override def decode(raw: Array[Byte]): F[String] = F.catchNonFatal(new String(raw, "UTF-8"))
+      override def decode(raw: Array[Byte]): F[String] = F.catchNonFatal(new String(raw, UTF_8))
     }
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoder.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoder.scala
@@ -18,6 +18,11 @@ package com.github.gvolpe.fs2rabbit.effects
 
 import cats.ApplicativeError
 
+/**
+  * Typeclass that provides the machinery to decode a given AMQP Envelope's payload.
+  *
+  * There's a default instance for decoding payloads into a UTF-8 String.
+  * */
 trait EnvelopeDecoder[F[_], A] {
   def decode(raw: Array[Byte]): F[A]
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoder.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoder.scala
@@ -36,9 +36,10 @@ object EnvelopeDecoder {
 
   implicit def utf8StringDecoder[F[_]](implicit F: ApplicativeError[F, Throwable]): EnvelopeDecoder[F, String] =
     new EnvelopeDecoder[F, String] {
-      override def decode(raw: Array[Byte], properties: AmqpProperties): F[String] = {
-        val encoding = properties.contentEncoding.fold(UTF_8)(Charset.forName)
-        F.catchNonFatal(new String(raw, encoding))
-      }
+      override def decode(raw: Array[Byte], properties: AmqpProperties): F[String] =
+        F.catchNonFatal {
+          val encoding = properties.contentEncoding.fold(UTF_8)(Charset.forName)
+          new String(raw, encoding)
+        }
     }
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/Log.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/Log.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Fs2 Rabbit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.fs2rabbit.effects
+
+import cats.effect.Sync
+import org.slf4j.LoggerFactory
+
+trait Log[F[_]] {
+  def info(value: String): F[Unit]
+  def error(error: Throwable): F[Unit]
+}
+
+object Log {
+  private[fs2rabbit] val logger = LoggerFactory.getLogger(this.getClass)
+
+  def apply[F[_]](implicit ev: Log[F]): Log[F] = ev
+
+  implicit def syncLogInstance[F[_]](implicit F: Sync[F]): Log[F] =
+    new Log[F] {
+      override def error(error: Throwable): F[Unit] = F.delay(logger.error(error.getMessage, error))
+      override def info(value: String): F[Unit]     = F.delay(logger.info(value))
+    }
+}

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/StreamEval.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/StreamEval.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit.util
+package com.github.gvolpe.fs2rabbit.effects
 
 import cats.effect.Sync
 import cats.syntax.functor._

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -57,7 +57,7 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
           val props = AmqpProperties.from(properties)
           internals.queue.fold(()) { internalQ =>
             decoder
-              .decode(body)
+              .decode(body, props)
               .flatMap { msg =>
                 internalQ.enqueue1(Right(AmqpEnvelope(DeliveryTag(tag), msg, props)))
               }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStream.scala
@@ -25,7 +25,7 @@ import cats.syntax.functor._
 import com.github.gvolpe.fs2rabbit.algebra.Connection
 import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.model.{AMQPChannel, RabbitChannel}
-import com.github.gvolpe.fs2rabbit.util.Log
+import com.github.gvolpe.fs2rabbit.effects.Log
 import com.rabbitmq.client.{ConnectionFactory, Connection => RabbitMQConnection}
 import fs2.Stream
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -45,7 +45,7 @@ object Fs2Rabbit {
 }
 // $COVERAGE-ON$
 
-private[fs2rabbit] class Fs2Rabbit[F[_]: Concurrent](
+class Fs2Rabbit[F[_]: Concurrent] private (
     config: Fs2RabbitConfig,
     connectionStream: Connection[Stream[F, ?]],
     amqpClient: AMQPClient[Stream[F, ?], F],

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -45,7 +45,7 @@ object Fs2Rabbit {
 }
 // $COVERAGE-ON$
 
-class Fs2Rabbit[F[_]: Concurrent] private (
+class Fs2Rabbit[F[_]: Concurrent] private[fs2rabbit] (
     config: Fs2RabbitConfig,
     connectionStream: Connection[Stream[F, ?]],
     amqpClient: AMQPClient[Stream[F, ?], F],

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
@@ -26,11 +26,11 @@ import scala.collection.JavaConverters._
 
 object model {
 
-  type StreamAcker[F[_]]         = Sink[F, AckResult]
-  type StreamConsumer[F[_]]      = Stream[F, AmqpEnvelope]
-  type StreamAckerConsumer[F[_]] = (StreamAcker[F], StreamConsumer[F])
-  type StreamPublisher[F[_]]     = Sink[F, AmqpMessage[String]]
-  type PublishingListener[F[_]]  = PublishReturn => F[Unit]
+  type StreamAcker[F[_]]            = Sink[F, AckResult]
+  type StreamConsumer[F[_], A]      = Stream[F, AmqpEnvelope[A]]
+  type StreamAckerConsumer[F[_], A] = (StreamAcker[F], StreamConsumer[F, A])
+  type StreamPublisher[F[_]]        = Sink[F, AmqpMessage[String]]
+  type PublishingListener[F[_]]     = PublishReturn => F[Unit]
 
   trait AMQPChannel {
     def value: Channel
@@ -151,7 +151,7 @@ object model {
     }
   }
 
-  case class AmqpEnvelope(deliveryTag: DeliveryTag, payload: String, properties: AmqpProperties)
+  case class AmqpEnvelope[A](deliveryTag: DeliveryTag, payload: A, properties: AmqpProperties)
   case class AmqpMessage[A](payload: A, properties: AmqpProperties)
 
   // Binding

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerProgram.scala
@@ -23,7 +23,7 @@ import com.github.gvolpe.fs2rabbit.model._
 import com.rabbitmq.client.Channel
 import fs2.{Sink, Stream}
 
-class AckerProgram[F[_]](config: Fs2RabbitConfig, AMQP: AMQPClient[Stream[F, ?], F]) extends Acker[Stream[F, ?]] {
+class AckerProgram[F[_], A](config: Fs2RabbitConfig, AMQP: AMQPClient[Stream[F, ?], F, A]) extends Acker[Stream[F, ?]] {
 
   def createAcker(channel: Channel): Sink[F, AckResult] =
     _.flatMap {

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerProgram.scala
@@ -23,7 +23,7 @@ import com.github.gvolpe.fs2rabbit.model._
 import com.rabbitmq.client.Channel
 import fs2.{Sink, Stream}
 
-class AckerProgram[F[_], A](config: Fs2RabbitConfig, AMQP: AMQPClient[Stream[F, ?], F, A]) extends Acker[Stream[F, ?]] {
+class AckerProgram[F[_]](config: Fs2RabbitConfig, AMQP: AMQPClient[Stream[F, ?], F]) extends Acker[Stream[F, ?]] {
 
   def createAcker(channel: Channel): Sink[F, AckResult] =
     _.flatMap {

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/PublishingProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/PublishingProgram.scala
@@ -22,7 +22,7 @@ import com.github.gvolpe.fs2rabbit.effects.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.Stream
 
-class PublishingProgram[F[_], A](AMQP: AMQPClient[Stream[F, ?], F, A])(implicit SE: StreamEval[F])
+class PublishingProgram[F[_]](AMQP: AMQPClient[Stream[F, ?], F])(implicit SE: StreamEval[F])
     extends Publishing[Stream[F, ?], F] {
 
   override def createPublisher(

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStream.scala
@@ -18,7 +18,7 @@ package com.github.gvolpe.fs2rabbit.resiliency
 
 import cats.effect.{Sync, Timer}
 import cats.syntax.apply._
-import com.github.gvolpe.fs2rabbit.util.Log
+import com.github.gvolpe.fs2rabbit.effects.Log
 import fs2.Stream
 
 import scala.concurrent.duration._

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoderSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Fs2 Rabbit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.gvolpe.fs2rabbit.effects
 
 import java.nio.charset.StandardCharsets

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoderSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoderSpec.scala
@@ -1,0 +1,58 @@
+package com.github.gvolpe.fs2rabbit.effects
+
+import java.nio.charset.StandardCharsets
+
+import cats.data.EitherT
+import cats.effect.{IO, SyncIO}
+import cats.instances.either._
+import cats.instances.try_._
+import com.github.gvolpe.fs2rabbit.model.AmqpProperties
+import org.scalatest.AsyncFunSuite
+
+import scala.util.Try
+
+class EnvelopeDecoderSpec extends AsyncFunSuite {
+
+  // Available instances of EnvelopeDecoder for any ApplicativeError[F, Throwable]
+  EnvelopeDecoder[Either[Throwable, ?], String]
+  EnvelopeDecoder[SyncIO, String]
+  EnvelopeDecoder[EitherT[IO, String, ?], String]
+  EnvelopeDecoder[Try, String]
+
+  test("should decode a UTF-8 string") {
+    val msg = "hello world!"
+    val raw = msg.getBytes(StandardCharsets.UTF_8)
+
+    EnvelopeDecoder[IO, String]
+      .decode(raw, AmqpProperties.empty)
+      .flatMap { result =>
+        IO(assert(result == msg))
+      }
+      .unsafeToFuture()
+  }
+
+  test("should decode payload with the given content encoding") {
+    val msg = "hello world!"
+    val raw = msg.getBytes(StandardCharsets.UTF_8)
+
+    EnvelopeDecoder[IO, String]
+      .decode(raw, AmqpProperties.empty.copy(contentEncoding = Some("UTF-16")))
+      .flatMap { result =>
+        IO(assert(result != msg))
+      }
+      .unsafeToFuture()
+  }
+
+  test("should decode a UTF-16 string into a UTF-8 (default)") {
+    val msg = "hello world!"
+    val raw = msg.getBytes(StandardCharsets.UTF_16)
+
+    EnvelopeDecoder[IO, String]
+      .decode(raw, AmqpProperties.empty)
+      .flatMap { result =>
+        IO(assert(result != msg))
+      }
+      .unsafeToFuture()
+  }
+
+}

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStub.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStub.scala
@@ -19,7 +19,7 @@ package com.github.gvolpe.fs2rabbit.interpreter
 import cats.effect.IO
 import com.github.gvolpe.fs2rabbit.algebra.Connection
 import com.github.gvolpe.fs2rabbit.model.AMQPChannel
-import com.github.gvolpe.fs2rabbit.util.StreamEval
+import com.github.gvolpe.fs2rabbit.effects.StreamEval
 import com.rabbitmq.client.Channel
 import fs2.Stream
 

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStreamSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStreamSpec.scala
@@ -19,7 +19,7 @@ package com.github.gvolpe.fs2rabbit.resiliency
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import cats.syntax.apply._
-import com.github.gvolpe.fs2rabbit.util.Log
+import com.github.gvolpe.fs2rabbit.effects.Log
 import fs2._
 import org.scalatest.{FlatSpecLike, Matchers}
 

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AutoAckConsumerDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AutoAckConsumerDemo.scala
@@ -27,7 +27,7 @@ import com.github.gvolpe.fs2rabbit.model._
 import com.github.gvolpe.fs2rabbit.effects.StreamEval
 import fs2.{Pipe, Stream}
 
-class AutoAckConsumerDemo[F[_]: Concurrent, A](implicit R: Fs2Rabbit[F, A]) {
+class AutoAckConsumerDemo[F[_]: Concurrent](implicit R: Fs2Rabbit[F]) {
 
   private val queueName    = QueueName("testQ")
   private val exchangeName = ExchangeName("testEX")
@@ -35,7 +35,7 @@ class AutoAckConsumerDemo[F[_]: Concurrent, A](implicit R: Fs2Rabbit[F, A]) {
 
   def putStrLn(str: String): F[Unit] = Sync[F].delay(println(str))
 
-  def logPipe: Pipe[F, AmqpEnvelope[A], AckResult] = _.evalMap { amqpMsg =>
+  def logPipe: Pipe[F, AmqpEnvelope[String], AckResult] = _.evalMap { amqpMsg =>
     putStrLn(s"Consumed: $amqpMsg").as(Ack(amqpMsg.deliveryTag))
   }
 
@@ -44,9 +44,9 @@ class AutoAckConsumerDemo[F[_]: Concurrent, A](implicit R: Fs2Rabbit[F, A]) {
       _         <- R.declareQueue(DeclarationQueueConfig.default(queueName))
       _         <- R.declareExchange(exchangeName, ExchangeType.Topic)
       _         <- R.bindQueue(queueName, exchangeName, routingKey)
-      consumer  <- R.createAutoAckConsumer(queueName)
+      consumer  <- R.createAutoAckConsumer[String](queueName)
       publisher <- R.createPublisher(exchangeName, routingKey)
-      result    <- new AutoAckFlow(consumer, logPipe, publisher).flow
+      result    <- new AutoAckFlow[F, String](consumer, logPipe, publisher).flow
     } yield result
   }
 

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
@@ -36,9 +36,9 @@ object IOAckerConsumer extends IOApp {
   )
 
   override def run(args: List[String]): IO[ExitCode] =
-    Fs2Rabbit[IO](config).flatMap { implicit fs2Rabbit =>
+    Fs2Rabbit[IO, String](config).flatMap { implicit fs2Rabbit =>
       ResilientStream
-        .run(new AckerConsumerDemo[IO]().program)
+        .run(new AckerConsumerDemo[IO, String]().program)
         .as(ExitCode.Success)
     }
 

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
@@ -36,9 +36,9 @@ object IOAckerConsumer extends IOApp {
   )
 
   override def run(args: List[String]): IO[ExitCode] =
-    Fs2Rabbit[IO, String](config).flatMap { implicit fs2Rabbit =>
+    Fs2Rabbit[IO](config).flatMap { implicit fs2Rabbit =>
       ResilientStream
-        .run(new AckerConsumerDemo[IO, String]().program)
+        .run(new AckerConsumerDemo[IO]().program)
         .as(ExitCode.Success)
     }
 

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -37,9 +37,9 @@ object MonixAutoAckConsumer extends TaskApp {
   )
 
   override def run(args: List[String]): Task[ExitCode] =
-    Fs2Rabbit[Task, String](config).flatMap { implicit fs2Rabbit =>
+    Fs2Rabbit[Task](config).flatMap { implicit fs2Rabbit =>
       ResilientStream
-        .run(new AutoAckConsumerDemo[Task, String].program)
+        .run(new AutoAckConsumerDemo[Task].program)
         .as(ExitCode.Success)
     }
 

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -37,9 +37,9 @@ object MonixAutoAckConsumer extends TaskApp {
   )
 
   override def run(args: List[String]): Task[ExitCode] =
-    Fs2Rabbit[Task](config).flatMap { implicit fs2Rabbit =>
+    Fs2Rabbit[Task, String](config).flatMap { implicit fs2Rabbit =>
       ResilientStream
-        .run(new AutoAckConsumerDemo[Task].program)
+        .run(new AutoAckConsumerDemo[Task, String].program)
         .as(ExitCode.Success)
     }
 

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonDecoder.scala
@@ -18,7 +18,7 @@ package com.github.gvolpe.fs2rabbit.json
 
 import cats.effect.Sync
 import com.github.gvolpe.fs2rabbit.model.{AmqpEnvelope, DeliveryTag}
-import com.github.gvolpe.fs2rabbit.util.Log
+import com.github.gvolpe.fs2rabbit.effects.Log
 import fs2.{Pipe, Stream}
 import io.circe.parser.decode
 import io.circe.{Decoder, Error}
@@ -47,7 +47,7 @@ class Fs2JsonDecoder[F[_]: Log: Sync] {
     *
     * The result will be a tuple (`Either` of `Error` and `A`, `DeliveryTag`)
     * */
-  def jsonDecode[A: Decoder]: Pipe[F, AmqpEnvelope, (Either[Error, A], DeliveryTag)] = _.flatMap { amqpMsg =>
+  def jsonDecode[A: Decoder]: Pipe[F, AmqpEnvelope[String], (Either[Error, A], DeliveryTag)] = _.flatMap { amqpMsg =>
     Stream
       .eval(Sync[F].delay(decode[A](amqpMsg.payload)))
       .evalTap(p => Log[F].info(s"Parsed: $p"))

--- a/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
+++ b/json-circe/src/main/scala/com/github/gvolpe/fs2rabbit/json/Fs2JsonEncoder.scala
@@ -17,7 +17,7 @@
 package com.github.gvolpe.fs2rabbit.json
 
 import com.github.gvolpe.fs2rabbit.model.AmqpMessage
-import com.github.gvolpe.fs2rabbit.util.StreamEval
+import com.github.gvolpe.fs2rabbit.effects.StreamEval
 import fs2.Pipe
 import io.circe.Encoder
 import io.circe.Printer

--- a/site/src/main/tut/consumers/ackerconsumer.md
+++ b/site/src/main/tut/consumers/ackerconsumer.md
@@ -16,12 +16,12 @@ import fs2._
 
 val queueName = QueueName("daQ")
 
-def doSomething(consumer: StreamConsumer[IO], acker: StreamAcker[IO]): Stream[IO, Unit] = Stream.eval(IO.unit)
+def doSomething(consumer: StreamConsumer[IO, String], acker: StreamAcker[IO]): Stream[IO, Unit] = Stream.eval(IO.unit)
 
 def program(implicit R: Fs2Rabbit[IO]) =
   R.createConnectionChannel.flatMap { implicit channel =>       // Stream[IO, AMQPChannel]
     for {
-      (acker, consumer) <- R.createAckerConsumer(queueName)	    // (StreamAcker[IO], StreamConsumer[IO])
+      (acker, consumer) <- R.createAckerConsumer[String](queueName)	    // (StreamAcker[IO], StreamConsumer[IO, String])
       _                 <- doSomething(consumer, acker)
     } yield ()
   }

--- a/site/src/main/tut/consumers/autoackconsumer.md
+++ b/site/src/main/tut/consumers/autoackconsumer.md
@@ -16,12 +16,12 @@ import fs2._
 
 val queueName = QueueName("daQ")
 
-def doSomething(consumer: StreamConsumer[IO]): Stream[IO, Unit] = Stream.eval(IO.unit)
+def doSomething(consumer: StreamConsumer[IO, String]): Stream[IO, Unit] = Stream.eval(IO.unit)
 
 def program(implicit R: Fs2Rabbit[IO]) =
   R.createConnectionChannel.flatMap { implicit channel => // Stream[IO, AMQPChannel]
     for {
-      c <- R.createAutoAckConsumer(queueName)	            // StreamConsumer[IO]
+      c <- R.createAutoAckConsumer[String](queueName)	    // StreamConsumer[IO, String]
       _ <- doSomething(c)
     } yield ()
   }

--- a/site/src/main/tut/consumers/index.md
+++ b/site/src/main/tut/consumers/index.md
@@ -16,9 +16,11 @@ When creating a consumer, either by using `createAutoAckConsumer` or `createAcke
 
 ```scala
 trait EnvelopeDecoder[F[_], A] {
-  def decode(raw: Array[Byte]): F[A]
+  def decode(raw: Array[Byte], properties: AmqpProperties): F[A]
 }
 ```
+
+You could check the `contentType` and `contentEncoding` values to decide how to decode the payload.
 
 - **[AutoAckConsumer](./autoackconsumer.html)**: A consumer that acknowledges message consumption automatically.
 - **[AckerConsumer](./ackerconsumer)**: A consumer that delegates the responsibility to acknowledge message consumption to the user.

--- a/site/src/main/tut/consumers/index.md
+++ b/site/src/main/tut/consumers/index.md
@@ -6,6 +6,20 @@ number: 6
 
 # Consumers
 
+There are two types of consumer: `AutoAck` and `AckerConsumer`. Each of them are parameterized on the effect type (eg. `IO`) and the data type it consumes (the payload). It's defined as below:
+
+```scala
+type StreamConsumer[F[_], A] = Stream[F, AmqpEnvelope[A]]
+```
+
+When creating a consumer, either by using `createAutoAckConsumer` or `createAckerConsumer`, you'll need an instance of `EnvelopeDecoder[A]` available in scope. A default instance for `UTF-8` encoding is provided by the library but if you wish to decode the envelope's payload in a different format you'll need to provide an implicit instance. Here's the definition:
+
+```scala
+trait EnvelopeDecoder[F[_], A] {
+  def decode(raw: Array[Byte]): F[A]
+}
+```
+
 - **[AutoAckConsumer](./autoackconsumer.html)**: A consumer that acknowledges message consumption automatically.
 - **[AckerConsumer](./ackerconsumer)**: A consumer that delegates the responsibility to acknowledge message consumption to the user.
 - **[Consuming Json](./json.html)**: Consuming Json messages using the `fs2-rabbit-circe` module.

--- a/site/src/main/tut/consumers/json.md
+++ b/site/src/main/tut/consumers/json.md
@@ -22,7 +22,7 @@ case class Person(id: Long, name: String, address: Address)
 
 object ioDecoder extends Fs2JsonDecoder[IO]
 
-def program(consumer: StreamConsumer[IO], acker: StreamAcker[IO], errorSink: Sink[IO, Error], processorSink: Sink[IO, (Person, DeliveryTag)]) = {
+def program(consumer: StreamConsumer[IO, String], acker: StreamAcker[IO], errorSink: Sink[IO, Error], processorSink: Sink[IO, (Person, DeliveryTag)]) = {
   import ioDecoder._
 
   (consumer through jsonDecode[Person]).flatMap {

--- a/site/src/main/tut/examples/sample-mult-connections.md
+++ b/site/src/main/tut/examples/sample-mult-connections.md
@@ -40,7 +40,7 @@ def p1(implicit F: Fs2Rabbit[IO]) = F.createConnectionChannel.flatMap { implicit
     _  <- F.declareExchange(ex, ExchangeType.Topic)
     _  <- F.declareQueue(DeclarationQueueConfig.default(q1))
     _  <- F.bindQueue(q1, ex, rk)
-    c1 <- F.createAutoAckConsumer(q1)
+    c1 <- F.createAutoAckConsumer[String](q1)
   } yield c1
 }
 ```
@@ -53,7 +53,7 @@ def p2(implicit F: Fs2Rabbit[IO]) = F.createConnectionChannel.flatMap { implicit
     _  <- F.declareExchange(ex, ExchangeType.Topic)
     _  <- F.declareQueue(DeclarationQueueConfig.default(q1))
     _  <- F.bindQueue(q1, ex, rk)
-    c2 <- F.createAutoAckConsumer(q1)
+    c2 <- F.createAutoAckConsumer[String](q1)
   } yield c2
 }
 ```
@@ -72,7 +72,7 @@ def p3(implicit F: Fs2Rabbit[IO]) = F.createConnectionChannel.flatMap { implicit
 And finally we compose all the three programs together:
 
 ```tut:book:silent
-val pipe: Pipe[IO, AmqpEnvelope, AmqpMessage[String]] = _.map(env => AmqpMessage(env.payload, AmqpProperties.empty))
+val pipe: Pipe[IO, AmqpEnvelope[String], AmqpMessage[String]] = _.map(env => AmqpMessage(env.payload, AmqpProperties.empty))
 
 def program(implicit F: Fs2Rabbit[IO]) =
   for {

--- a/site/src/main/tut/examples/sample-mult-consumers.md
+++ b/site/src/main/tut/examples/sample-mult-consumers.md
@@ -27,7 +27,7 @@ val rkb = RoutingKey("RKB")
 
 val msg = Stream(AmqpMessage("Hey!", AmqpProperties.empty)).covary[IO]
 
-def multipleConsumers(c1: StreamConsumer[IO], c2: StreamConsumer[IO], p: StreamPublisher[IO]) = {
+def multipleConsumers(c1: StreamConsumer[IO, String], c2: StreamConsumer[IO, String], p: StreamPublisher[IO]) = {
   Stream(
     msg to p,
     c1 to (_.evalMap(m => IO(println(s"Consumer #1 >> $m")))),
@@ -42,8 +42,8 @@ def program(F: Fs2Rabbit[IO]) = F.createConnectionChannel.flatMap { implicit cha
       _  <- F.declareQueue(DeclarationQueueConfig.default(q2))
       _  <- F.bindQueue(q1, ex, rka)
       _  <- F.bindQueue(q2, ex, rkb)
-      c1 <- F.createAutoAckConsumer(q1)
-      c2 <- F.createAutoAckConsumer(q2)
+      c1 <- F.createAutoAckConsumer[String](q1)
+      c2 <- F.createAutoAckConsumer[String](q2)
       p  <- F.createPublisher(ex, rka)
       _  <- multipleConsumers(c1, c2, p)
     } yield ()

--- a/site/src/main/tut/exchanges.md
+++ b/site/src/main/tut/exchanges.md
@@ -22,7 +22,7 @@ import fs2._
 val x1 = ExchangeName("x1")
 val x2 = ExchangeName("x2")
 
-def exchanges(implicit F: Fs2Rabbit[IO]) = F.createConnectionChannel flatMap { implicit channel =>
+def exchanges(implicit F: Fs2Rabbit[IO]) = F.createConnectionChannel.flatMap { implicit channel =>
   for {
     _ <- F.declareExchange(x1, ExchangeType.Topic)
     _ <- F.declareExchange(x2, ExchangeType.FanOut)
@@ -40,7 +40,7 @@ import fs2._
 
 val x = ExchangeName("x")
 
-def exchanges(implicit F: Fs2Rabbit[IO]) = F.createConnectionChannel flatMap { implicit channel =>
+def exchanges(implicit F: Fs2Rabbit[IO]) = F.createConnectionChannel.flatMap { implicit channel =>
   for {
     _ <- F.declareExchangePassive(x)
   } yield ()


### PR DESCRIPTION
Here's a second design of #124  @mberndt123

It only places the `EnvelopeDecoder` constraint on the consumer related methods instead of at the top. I don't normally like to place typeclass constraints on the algebras but this is one way to achieve such goal.

Still the question about when would you need to decode the given payload which is of type `Array[Byte]` into something different than a `UTF-8 String`?

Note: Tests were not fixed either.

closes #123 