### PR TITLE
Simplify StreamAcker and StreamPublisher

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
@@ -25,8 +25,8 @@ import com.rabbitmq.client.Channel
 
 // format: off
 trait AMQPClient[F[_], G[_]] extends Binding[F] with Declaration[F] with Deletion[F] {
-  def basicAck(channel: Channel, tag: DeliveryTag, multiple: Boolean): F[Unit]
-  def basicNack(channel: Channel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit]
+  def basicAck(channel: Channel, tag: DeliveryTag, multiple: Boolean): G[Unit]
+  def basicNack(channel: Channel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): G[Unit]
   def basicQos(channel: Channel, basicQos: BasicQos): F[Unit]
   def basicConsume[A](channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Arguments)
                   (internals: AMQPInternals[G, A])(implicit decoder: EnvelopeDecoder[G, A]): F[String]

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
@@ -30,8 +30,8 @@ trait AMQPClient[F[_], G[_]] extends Binding[F] with Declaration[F] with Deletio
   def basicQos(channel: Channel, basicQos: BasicQos): F[Unit]
   def basicConsume[A](channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: String, noLocal: Boolean, exclusive: Boolean, args: Arguments)
                   (internals: AMQPInternals[G, A])(implicit decoder: EnvelopeDecoder[G, A]): F[String]
-  def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[String]): F[Unit]
-  def basicPublishWithFlag(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, flag: PublishingFlag, msg: AmqpMessage[String]): F[Unit]
+  def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[String]): G[Unit]
+  def basicPublishWithFlag(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, flag: PublishingFlag, msg: AmqpMessage[String]): G[Unit]
   def addPublishingListener(channel: Channel, listener: PublishingListener[G]): F[Unit]
   def clearPublishingListeners(channel: Channel): F[Unit]
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Acker.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Acker.scala
@@ -16,9 +16,9 @@
 
 package com.github.gvolpe.fs2rabbit.algebra
 
-import com.github.gvolpe.fs2rabbit.model.AckResult
+import com.github.gvolpe.fs2rabbit.model.StreamAcker
 import com.rabbitmq.client.Channel
 
 trait Acker[F[_]] {
-  def createAcker(channel: Channel): F[AckResult => F[Unit]]
+  def createAcker(channel: Channel): F[StreamAcker[F]]
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Acker.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Acker.scala
@@ -20,5 +20,5 @@ import com.github.gvolpe.fs2rabbit.model.AckResult
 import com.rabbitmq.client.Channel
 
 trait Acker[F[_]] {
-  def createAcker(channel: Channel): F[AckResult] => F[Unit]
+  def createAcker(channel: Channel): F[AckResult => F[Unit]]
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
@@ -17,7 +17,7 @@
 package com.github.gvolpe.fs2rabbit.algebra
 
 import com.github.gvolpe.fs2rabbit.effects.EnvelopeDecoder
-import com.github.gvolpe.fs2rabbit.model.{AckResult, AmqpEnvelope, BasicQos, ConsumerArgs, QueueName}
+import com.github.gvolpe.fs2rabbit.model._
 import com.rabbitmq.client.Channel
 
 trait Consuming[F[_], G[_]] {
@@ -27,7 +27,7 @@ trait Consuming[F[_], G[_]] {
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  )(implicit decoder: EnvelopeDecoder[G, A]): F[(AckResult => G[Unit], F[AmqpEnvelope[A]])]
+  )(implicit decoder: EnvelopeDecoder[G, A]): F[(StreamAcker[G], F[AmqpEnvelope[A]])]
 
   def createAutoAckConsumer[A](
       channel: Channel,

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
@@ -27,7 +27,7 @@ trait Consuming[F[_], G[_]] {
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  )(implicit decoder: EnvelopeDecoder[G, A]): F[(F[AckResult] => F[Unit], F[AmqpEnvelope[A]])]
+  )(implicit decoder: EnvelopeDecoder[G, A]): F[(AckResult => G[Unit], F[AmqpEnvelope[A]])]
 
   def createAutoAckConsumer[A](
       channel: Channel,

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Publishing.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Publishing.scala
@@ -25,7 +25,7 @@ trait Publishing[F[_], G[_]] {
       channel: Channel,
       exchangeName: ExchangeName,
       routingKey: RoutingKey
-  ): F[F[AmqpMessage[String]] => F[Unit]]
+  ): F[StreamPublisher[G]]
 
   def createPublisherWithListener(
       channel: Channel,
@@ -33,6 +33,6 @@ trait Publishing[F[_], G[_]] {
       routingKey: RoutingKey,
       flags: PublishingFlag,
       listener: PublishingListener[G]
-  ): F[F[AmqpMessage[String]] => F[Unit]]
+  ): F[StreamPublisher[G]]
 
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -113,7 +113,7 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       exchangeName: ExchangeName,
       routingKey: RoutingKey,
       msg: AmqpMessage[String]
-  ): F[Unit] = Effect[F].delay {
+  ): F[Unit] = Sync[F].delay {
     channel.basicPublish(
       exchangeName.value,
       routingKey.value,
@@ -128,7 +128,7 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       routingKey: RoutingKey,
       flag: PublishingFlag,
       msg: AmqpMessage[String]
-  ): F[Unit] = Effect[F].delay {
+  ): F[Unit] = Sync[F].delay {
     channel.basicPublish(
       exchangeName.value,
       routingKey.value,

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -113,7 +113,7 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       exchangeName: ExchangeName,
       routingKey: RoutingKey,
       msg: AmqpMessage[String]
-  ): Stream[F, Unit] = SE.evalDiscard {
+  ): F[Unit] = Effect[F].delay {
     channel.basicPublish(
       exchangeName.value,
       routingKey.value,
@@ -128,7 +128,7 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       routingKey: RoutingKey,
       flag: PublishingFlag,
       msg: AmqpMessage[String]
-  ): Stream[F, Unit] = SE.evalDiscard {
+  ): F[Unit] = Effect[F].delay {
     channel.basicPublish(
       exchangeName.value,
       routingKey.value,

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -16,7 +16,7 @@
 
 package com.github.gvolpe.fs2rabbit.interpreter
 
-import cats.effect.Effect
+import cats.effect.{Effect, Sync}
 import cats.effect.syntax.effect._
 import cats.syntax.flatMap._
 import com.github.gvolpe.fs2rabbit.algebra.{AMQPClient, AMQPInternals}
@@ -73,7 +73,7 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       channel: Channel,
       tag: DeliveryTag,
       multiple: Boolean
-  ): Stream[F, Unit] = SE.evalDiscard {
+  ): F[Unit] = Sync[F].delay {
     channel.basicAck(tag.value, multiple)
   }
 
@@ -82,8 +82,8 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       tag: DeliveryTag,
       multiple: Boolean,
       requeue: Boolean
-  ): Stream[F, Unit] =
-    SE.evalDiscard {
+  ): F[Unit] =
+    Sync[F].delay {
       channel.basicNack(tag.value, multiple, requeue)
     }
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -65,8 +65,7 @@ class Fs2Rabbit[F[_]: Concurrent] private[fs2rabbit] (
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  )(implicit channel: AMQPChannel,
-    decoder: EnvelopeDecoder[F, A]): Stream[F, (AckResult => F[Unit], StreamConsumer[F, A])] =
+  )(implicit channel: AMQPChannel, decoder: EnvelopeDecoder[F, A]): Stream[F, (StreamAcker[F], StreamConsumer[F, A])] =
     consumingProgram.createAckerConsumer(channel.value, queueName, basicQos, consumerArgs)
 
   def createAutoAckConsumer[A](

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -49,7 +49,7 @@ class Fs2Rabbit[F[_]: Concurrent] private[fs2rabbit] (
     config: Fs2RabbitConfig,
     connectionStream: Connection[Stream[F, ?]],
     amqpClient: AMQPClient[Stream[F, ?], F],
-    acker: Acker[Stream[F, ?]],
+    acker: Acker[F],
     consumer: Consumer[Stream[F, ?], F]
 ) {
 
@@ -65,7 +65,8 @@ class Fs2Rabbit[F[_]: Concurrent] private[fs2rabbit] (
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  )(implicit channel: AMQPChannel, decoder: EnvelopeDecoder[F, A]): Stream[F, (StreamAcker[F], StreamConsumer[F, A])] =
+  )(implicit channel: AMQPChannel,
+    decoder: EnvelopeDecoder[F, A]): Stream[F, (AckResult => F[Unit], StreamConsumer[F, A])] =
     consumingProgram.createAckerConsumer(channel.value, queueName, basicQos, consumerArgs)
 
   def createAutoAckConsumer[A](

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
@@ -33,7 +33,7 @@ import scala.collection.JavaConverters._
 
 object model {
 
-  type StreamAcker[F[_]]            = Sink[F, AckResult]
+  type StreamAcker[F[_]]            = AckResult => F[Unit]
   type StreamConsumer[F[_], A]      = Stream[F, AmqpEnvelope[A]]
   type StreamAckerConsumer[F[_], A] = (StreamAcker[F], StreamConsumer[F, A])
   type StreamPublisher[F[_]]        = Sink[F, AmqpMessage[String]]

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
@@ -26,7 +26,7 @@ import com.github.gvolpe.fs2rabbit.effects.EnvelopeDecoder
 import com.github.gvolpe.fs2rabbit.model.AmqpHeaderVal._
 import com.rabbitmq.client.impl.LongStringHelper
 import com.rabbitmq.client.{AMQP, Channel, LongString}
-import fs2.{Sink, Stream}
+import fs2.Stream
 import cats.implicits._
 
 import scala.collection.JavaConverters._
@@ -36,7 +36,7 @@ object model {
   type StreamAcker[F[_]]            = AckResult => F[Unit]
   type StreamConsumer[F[_], A]      = Stream[F, AmqpEnvelope[A]]
   type StreamAckerConsumer[F[_], A] = (StreamAcker[F], StreamConsumer[F, A])
-  type StreamPublisher[F[_]]        = Sink[F, AmqpMessage[String]]
+  type StreamPublisher[F[_]]        = AmqpMessage[String] => F[Unit]
   type PublishingListener[F[_]]     = PublishReturn => F[Unit]
 
   trait AMQPChannel {

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckerProgram.scala
@@ -27,7 +27,7 @@ import fs2.Stream
 class AckerProgram[F[_]](config: Fs2RabbitConfig, AMQP: AMQPClient[Stream[F, ?], F])(implicit F: Applicative[F])
     extends Acker[F] {
 
-  def createAcker(channel: Channel): F[AckResult => F[Unit]] =
+  def createAcker(channel: Channel): F[StreamAcker[F]] =
     F.pure {
       case Ack(tag)  => AMQP.basicAck(channel, tag, multiple = false)
       case NAck(tag) => AMQP.basicNack(channel, tag, multiple = false, config.requeueOnNack)

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/ConsumingProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/ConsumingProgram.scala
@@ -30,7 +30,7 @@ class ConsumingProgram[F[_]](A: Acker[F], C: Consumer[Stream[F, ?], F])(implicit
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  )(implicit decoder: EnvelopeDecoder[F, A]): Stream[F, (AckResult => F[Unit], StreamConsumer[F, A])] = {
+  )(implicit decoder: EnvelopeDecoder[F, A]): Stream[F, (StreamAcker[F], StreamConsumer[F, A])] = {
     val consumer = consumerArgs.fold(C.createConsumer(queueName, channel, basicQos)) { args =>
       C.createConsumer[A](
         queueName = queueName,

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -197,7 +197,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           (acker, consumer) = ackerConsumer
           _ <- Stream(
                 consumer.take(1) to testQ.enqueue,
-                Stream(Ack(DeliveryTag(1))).covary[IO].observe(ackerQ.enqueue) to acker
+                Stream(Ack(DeliveryTag(1))).covary[IO].observe(ackerQ.enqueue).evalMap(acker)
               ).parJoin(2).take(1)
           result    <- Stream.eval(testQ.dequeue1)
           ackResult <- Stream.eval(ackerQ.dequeue1)
@@ -223,7 +223,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         ackerConsumer     <- createAckerConsumer(queueName)
         (acker, consumer) = ackerConsumer
         result            <- consumer.take(1)
-        _                 <- (Stream(NAck(DeliveryTag(1))).covary[IO].observe(ackerQ.enqueue) to acker).take(1)
+        _                 <- (Stream(NAck(DeliveryTag(1))).covary[IO].observe(ackerQ.enqueue) evalMap acker).take(1)
         ackResult         <- Stream.eval(ackerQ.dequeue1)
       } yield {
         result should be(AmqpEnvelope(DeliveryTag(1), "NAck-test", AmqpProperties()))
@@ -299,7 +299,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           _                 <- msg.covary[IO] to publisher
           _ <- Stream(
                 consumer.take(1) to testQ.enqueue,
-                Stream(Ack(DeliveryTag(1))).covary[IO] observe ackerQ.enqueue to acker
+                Stream(Ack(DeliveryTag(1))).covary[IO] observe ackerQ.enqueue evalMap acker
               ).parJoin(2).take(1)
           result    <- Stream.eval(testQ.dequeue1)
           ackResult <- Stream.eval(ackerQ.dequeue1)
@@ -418,7 +418,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         _                 <- msg.covary[IO] to publisher
         _ <- Stream(
               consumer.take(1) to testQ.enqueue,
-              Stream(Ack(DeliveryTag(1))).covary[IO] observe ackerQ.enqueue to acker
+              Stream(Ack(DeliveryTag(1))).covary[IO] observe ackerQ.enqueue evalMap acker
             ).parJoin(2).take(1)
         result    <- Stream.eval(testQ.dequeue1)
         ackResult <- Stream.eval(ackerQ.dequeue1)
@@ -458,7 +458,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         ackerConsumer     <- createAckerConsumer(queueName)
         (acker, consumer) = ackerConsumer
         result            <- consumer.take(1)
-        _                 <- (Stream(NAck(DeliveryTag(1))).covary[IO].observe(ackerQ.enqueue) to acker).take(1)
+        _                 <- (Stream(NAck(DeliveryTag(1))).covary[IO].observe(ackerQ.enqueue) evalMap acker).take(1)
         _                 <- consumer.take(1) // Message will be re-queued
         ackResult         <- ackerQ.dequeue.take(1)
       } yield {

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AckerConsumerDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AckerConsumerDemo.scala
@@ -77,8 +77,8 @@ class Flow[F[_]: Concurrent, A](
 
   val flow: Stream[F, Unit] =
     Stream(
-      Stream(simpleMessage).covary[F].to(publisher),
-      Stream(classMessage).covary[F].through(jsonEncode[Person]).to(publisher),
+      Stream(simpleMessage).covary[F].evalMap(publisher),
+      Stream(classMessage).covary[F].through(jsonEncode[Person]).evalMap(publisher),
       consumer.through(logger).evalMap(acker)
     ).parJoin(3)
 

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AutoAckConsumerDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/AutoAckConsumerDemo.scala
@@ -72,8 +72,8 @@ class AutoAckFlow[F[_]: Concurrent, A](
 
   val flow: Stream[F, Unit] =
     Stream(
-      Stream(simpleMessage).covary[F] to publisher,
-      Stream(classMessage).covary[F] through jsonEncode[Person] to publisher,
+      Stream(simpleMessage).covary[F] evalMap publisher,
+      Stream(classMessage).covary[F] through jsonEncode[Person] evalMap publisher,
       consumer through logger to SE.liftSink(ack => Sync[F].delay(println(ack)))
     ).parJoin(3)
 

--- a/site/src/main/tut/consumers/json.md
+++ b/site/src/main/tut/consumers/json.md
@@ -26,7 +26,7 @@ def program(consumer: StreamConsumer[IO, String], acker: StreamAcker[IO], errorS
   import ioDecoder._
 
   (consumer through jsonDecode[Person]).flatMap {
-    case (Left(error), tag) => (Stream.eval(IO(error)) to errorSink).map(_ => NAck(tag)) to acker
+    case (Left(error), tag) => (Stream.eval(IO(error)) to errorSink).map(_ => NAck(tag)) evalMap acker
     case (Right(msg), tag)  => Stream.eval(IO((msg, tag))) to processorSink
   }
 }

--- a/site/src/main/tut/examples/sample-acker.md
+++ b/site/src/main/tut/examples/sample-acker.md
@@ -42,8 +42,8 @@ class Flow[F[_]: Concurrent](
 
   val flow: Stream[F, Unit] =
     Stream(
-      Stream(simpleMessage).covary[F] to publisher,
-      Stream(classMessage).covary[F] through jsonEncode[Person] to publisher,
+      Stream(simpleMessage).covary[F] evalMap publisher,
+      Stream(classMessage).covary[F] through jsonEncode[Person] evalMap publisher,
       consumer through logger evalMap acker
     ).parJoin(3)
 

--- a/site/src/main/tut/examples/sample-acker.md
+++ b/site/src/main/tut/examples/sample-acker.md
@@ -44,7 +44,7 @@ class Flow[F[_]: Concurrent](
     Stream(
       Stream(simpleMessage).covary[F] to publisher,
       Stream(classMessage).covary[F] through jsonEncode[Person] to publisher,
-      consumer through logger to acker
+      consumer through logger evalMap acker
     ).parJoin(3)
 
 }

--- a/site/src/main/tut/examples/sample-autoack.md
+++ b/site/src/main/tut/examples/sample-autoack.md
@@ -41,8 +41,8 @@ class AutoAckFlow[F[_]: Concurrent](
 
   val flow: Stream[F, Unit] =
     Stream(
-      Stream(simpleMessage).covary[F] to publisher,
-      Stream(classMessage).covary[F] through jsonEncode[Person] to publisher,
+      Stream(simpleMessage).covary[F] evalMap publisher,
+      Stream(classMessage).covary[F] through jsonEncode[Person] evalMap publisher,
       consumer through logger to SE.liftSink(ack => Sync[F].delay(println(ack)))
     ).parJoin(3)
 

--- a/site/src/main/tut/examples/sample-mult-connections.md
+++ b/site/src/main/tut/examples/sample-mult-connections.md
@@ -79,6 +79,6 @@ def program(implicit F: Fs2Rabbit[IO]) =
     c1 <- p1
     c2 <- p2
     pb <- p3
-    _  <- (c1 through pipe to pb).concurrently(c2 through pipe to pb)
+    _  <- (c1 through pipe evalMap pb).concurrently(c2 through pipe evalMap pb)
   } yield ()
 ```

--- a/site/src/main/tut/examples/sample-mult-consumers.md
+++ b/site/src/main/tut/examples/sample-mult-consumers.md
@@ -29,7 +29,7 @@ val msg = Stream(AmqpMessage("Hey!", AmqpProperties.empty)).covary[IO]
 
 def multipleConsumers(c1: StreamConsumer[IO, String], c2: StreamConsumer[IO, String], p: StreamPublisher[IO]) = {
   Stream(
-    msg to p,
+    msg evalMap p,
     c1 to (_.evalMap(m => IO(println(s"Consumer #1 >> $m")))),
     c2 to (_.evalMap(m => IO(println(s"Consumer #2 >> $m"))))
   ).parJoin(3)

--- a/site/src/main/tut/publishers/json.md
+++ b/site/src/main/tut/publishers/json.md
@@ -24,7 +24,7 @@ def program(publisher: StreamPublisher[IO]) = {
   import ioEncoder._
 
   val message = AmqpMessage(Person(1L, "Sherlock", Address(212, "Baker St")), AmqpProperties.empty)
-  Stream(message).covary[IO] through jsonEncode[Person] to publisher
+  Stream(message).covary[IO] through jsonEncode[Person] evalMap publisher
 }
 ```
 

--- a/site/src/main/tut/publishers/publisher-with-listener.md
+++ b/site/src/main/tut/publishers/publisher-with-listener.md
@@ -56,7 +56,7 @@ import fs2._
 
 def publishSimpleMessage[F[_]: Sync](publisher: StreamPublisher[F]): Stream[F, Unit] = {
   val message = AmqpMessage("Hello world!", AmqpProperties.empty)
-  Stream(message).covary[F] to publisher
+  Stream(message).covary[F] evalMap publisher
 }
 ```
 

--- a/site/src/main/tut/publishers/publisher.md
+++ b/site/src/main/tut/publishers/publisher.md
@@ -39,6 +39,6 @@ import fs2._
 
 def publishSimpleMessage[F[_]: Sync](publisher: StreamPublisher[F]): Stream[F, Unit] = {
   val message = AmqpMessage("Hello world!", AmqpProperties.empty)
-  Stream(message).covary[F] to publisher
+  Stream(message).covary[F] evalMap publisher
 }
 ```


### PR DESCRIPTION
Hi @gvolpe,

I've gained some experience with the library and I think that defining `StreamAcker` as a `Sink` is not the best possible choice. For instance, suppose you want to transform the stream of messages to some other stream and acknowledge the results along the way. With the current design, you have to do something like this: 
```scala
val consumer: StreamConsumer[F, A] = ???
val acker: StreamAcker[F] = ???
consumer.flatMap { a =>
  Stream.eval(doStuff(a)).flatMap { result =>
    Stream.emit(Ack(a.deliveryTag)).to(acker).drain ++ Stream.emit(result)
}
```

With my new definition, this is more straight-forward:
```scala
consumer.evalMap { a =>
  doStuff(a).flatMap { result =>
    acker(AckResult(a.deliveryTag)).as(result)
}
```
I feel like doing things in terms of `Stream[F, ?]` rather than `F` doesn't really buy you anything in this case and makes things more complicated (and inefficient, because it breaks fs2's chunking) instead. I also think it's a bit error-prone, because people are likely to `flatMap` over the `Stream[F, Unit]` that `.to(acker)` returns (instead of using `++`). If some day we change the implementation to return e. g. an empty `Stream[F, Unit]` instead of a `Stream[F, Unit]` containing a single `Unit` value, people's programs will break. I've seen people make that mistake too often to think that it's not going to happen :wink: 

Existing programs are trivial to adapt, because they probably just need to change from `.to(acker)` to `.evalMap(acker)`, as shown in the example programs.

Let me know what you think about the proposal.

I also feel that a similar reasoning can be applied to `StreamPublisher` (actually even more so!), so I'd like to propose a similar change for `StreamPublisher` too. But first let me know what you think!