### PR TITLE
Extend publishing algebra to delay the decision for a routing key

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Publishing.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Publishing.scala
@@ -36,4 +36,16 @@ trait Publishing[F[_], G[_]] {
       listener: PublishReturn => G[Unit]
   )(implicit encoder: MessageEncoder[G, A]): F[A => G[Unit]]
 
+  def createRoutingPublisher[A](
+      channel: Channel,
+      exchangeName: ExchangeName
+  )(implicit encoder: MessageEncoder[G, A]): F[RoutingKey => A => G[Unit]]
+
+  def createRoutingPublisherWithListener[A](
+      channel: Channel,
+      exchangeName: ExchangeName,
+      flags: PublishingFlag,
+      listener: PublishReturn => G[Unit]
+  )(implicit encoder: MessageEncoder[G, A]): F[RoutingKey => A => G[Unit]]
+
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -89,6 +89,18 @@ class Fs2Rabbit[F[_]: Concurrent] private[fs2rabbit] (
   )(implicit channel: AMQPChannel, encoder: MessageEncoder[F, A]): Stream[F, A => F[Unit]] =
     publishingProgram.createPublisherWithListener(channel.value, exchangeName, routingKey, flags, listener)
 
+  def createRoutingPublisher[A](exchangeName: ExchangeName)(
+      implicit channel: AMQPChannel,
+      encoder: MessageEncoder[F, A]): Stream[F, RoutingKey => A => F[Unit]] =
+    publishingProgram.createRoutingPublisher(channel.value, exchangeName)
+
+  def createRoutingPublisherWithListener[A](
+      exchangeName: ExchangeName,
+      flags: PublishingFlag,
+      listener: PublishReturn => F[Unit]
+  )(implicit channel: AMQPChannel, encoder: MessageEncoder[F, A]): Stream[F, RoutingKey => A => F[Unit]] =
+    publishingProgram.createRoutingPublisherWithListener(channel.value, exchangeName, flags, listener)
+
   def addPublishingListener(listener: PublishReturn => F[Unit])(implicit channel: AMQPChannel): Stream[F, Unit] =
     amqpClient.addPublishingListener(channel.value, listener)
 

--- a/site/src/main/tut/publishers/publisher-with-listener.md
+++ b/site/src/main/tut/publishers/publisher-with-listener.md
@@ -18,7 +18,7 @@ The server SHOULD implement the mandatory flag.
 
 ### Creating a Publisher with Listener
 
-It is simply created by specifying `ExchangeName`, `RoutingKey`, `PublishingFlag` and a `PublishingListener`. The latter is just a function from `PublishReturn` (a data structure) to `F[Unit]`:
+It is simply created by specifying `ExchangeName`, `RoutingKey`, `PublishingFlag` and a listener, i.e. a function from `PublishReturn` (a data structure) to `F[Unit]`:
 
 ```tut:book:silent
 import cats.effect.IO


### PR DESCRIPTION
I'd like to use this PR as a basis to discuss the introduction of some means to dynamically decide on routing keys for publishing.

This iteration proposes the introduction of two new methods `createRoutingPublisher` and `createRoutingPublisherWithListener` to the `Publishing`-algebra which
add the ability to create a `RoutingKey => Publisher[F]` (i.e. `RoutingKey => AmqpMessage[String] => F[Unit]`) to defer the decision for a routing key to the call site.

Another possibility that comes to mind is adding a `type RoutedAmqpMessage[A] = (RoutingKey, AmqpMessage[A])` and return `RoutedAmqpMessage[String] => F[Unit]`