### PR TITLE
Make `ConsumingProgram` pure

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/InternalQueue.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/InternalQueue.scala
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit.config
+package com.github.gvolpe.fs2rabbit.algebra
 
-case class Fs2RabbitConfig(
-    host: String,
-    port: Int,
-    virtualHost: String,
-    connectionTimeout: Int,
-    ssl: Boolean,
-    username: Option[String],
-    password: Option[String],
-    requeueOnNack: Boolean,
-    internalQueueSize: Option[Int]
-)
+import com.github.gvolpe.fs2rabbit.model.AmqpEnvelope
+import fs2.concurrent.Queue
+
+trait InternalQueue[F[_]] {
+  def create: F[Queue[F, Either[Throwable, AmqpEnvelope[Array[Byte]]]]]
+}

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -35,7 +35,7 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
       channel: Channel,
       internals: AMQPInternals[F]
   ): Stream[F, Consumer] =
-    SE.pure(
+    Stream(
       new DefaultConsumer(channel) {
 
         override def handleCancel(consumerTag: String): Unit =

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -37,7 +37,7 @@ object Fs2Rabbit {
     ConnectionStream.mkConnectionFactory[F](config, sslContext).map { factory =>
       val amqpClient = new AMQPClientStream[F]
       val connStream = new ConnectionStream[F](factory)
-      val internalQ  = new InternalQueueStream[F](config.internalQueueSize.getOrElse(500))
+      val internalQ  = new LiveInternalQueue[F](config.internalQueueSize.getOrElse(500))
       val acker      = new AckingProgram[F](config, amqpClient)
       val consumer   = new ConsumingProgram[F](amqpClient, internalQ)
       new Fs2Rabbit[F](config, connStream, amqpClient, acker, consumer)

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -37,8 +37,9 @@ object Fs2Rabbit {
     ConnectionStream.mkConnectionFactory[F](config, sslContext).map { factory =>
       val amqpClient = new AMQPClientStream[F]
       val connStream = new ConnectionStream[F](factory)
+      val internalQ  = new InternalQueueStream[F](config.internalQueueSize.getOrElse(500))
       val acker      = new AckingProgram[F](config, amqpClient)
-      val consumer   = new ConsumingProgram[F](amqpClient)
+      val consumer   = new ConsumingProgram[F](amqpClient, internalQ)
       new Fs2Rabbit[F](config, connStream, amqpClient, acker, consumer)
     }
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/InternalQueueStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/InternalQueueStream.scala
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit.config
+package com.github.gvolpe.fs2rabbit.interpreter
 
-case class Fs2RabbitConfig(
-    host: String,
-    port: Int,
-    virtualHost: String,
-    connectionTimeout: Int,
-    ssl: Boolean,
-    username: Option[String],
-    password: Option[String],
-    requeueOnNack: Boolean,
-    internalQueueSize: Option[Int]
-)
+import cats.effect.Concurrent
+import com.github.gvolpe.fs2rabbit.algebra.InternalQueue
+import com.github.gvolpe.fs2rabbit.model.AmqpEnvelope
+import fs2.concurrent.Queue
+
+class InternalQueueStream[F[_]: Concurrent](queueSize: Int) extends InternalQueue[F] {
+
+  override def create: F[Queue[F, Either[Throwable, AmqpEnvelope[Array[Byte]]]]] =
+    Queue.bounded[F, Either[Throwable, AmqpEnvelope[Array[Byte]]]](queueSize)
+
+}

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/LiveInternalQueue.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/LiveInternalQueue.scala
@@ -21,7 +21,7 @@ import com.github.gvolpe.fs2rabbit.algebra.InternalQueue
 import com.github.gvolpe.fs2rabbit.model.AmqpEnvelope
 import fs2.concurrent.Queue
 
-class InternalQueueStream[F[_]: Concurrent](queueSize: Int) extends InternalQueue[F] {
+class LiveInternalQueue[F[_]: Concurrent](queueSize: Int) extends InternalQueue[F] {
 
   override def create: F[Queue[F, Either[Throwable, AmqpEnvelope[Array[Byte]]]]] =
     Queue.bounded[F, Either[Throwable, AmqpEnvelope[Array[Byte]]]](queueSize)

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckingProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/AckingProgram.scala
@@ -24,11 +24,10 @@ import com.github.gvolpe.fs2rabbit.model._
 import com.rabbitmq.client.Channel
 import fs2.Stream
 
-class AckingProgram[F[_]](config: Fs2RabbitConfig, AMQP: AMQPClient[Stream[F, ?], F])(implicit F: Applicative[F])
-    extends Acking[F] {
+class AckingProgram[F[_]: Applicative](config: Fs2RabbitConfig, AMQP: AMQPClient[Stream[F, ?], F]) extends Acking[F] {
 
   def createAcker(channel: Channel): F[AckResult => F[Unit]] =
-    F.pure {
+    Applicative[F].pure {
       case Ack(tag)  => AMQP.basicAck(channel, tag, multiple = false)
       case NAck(tag) => AMQP.basicNack(channel, tag, multiple = false, config.requeueOnNack)
     }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStream.scala
@@ -37,12 +37,17 @@ import scala.util.control.NonFatal
   * */
 object ResilientStream {
 
-  def run[F[_]: Log: Sync: Timer](program: Stream[F, Unit], retry: FiniteDuration = 5.seconds): F[Unit] =
+  def run[F[_]: Log: Sync: Timer](
+      program: Stream[F, Unit],
+      retry: FiniteDuration = 5.seconds
+  ): F[Unit] =
     loop(program, retry, 1).compile.drain
 
-  private def loop[F[_]: Log: Sync: Timer](program: Stream[F, Unit],
-                                           retry: FiniteDuration,
-                                           count: Int): Stream[F, Unit] =
+  private def loop[F[_]: Log: Sync: Timer](
+      program: Stream[F, Unit],
+      retry: FiniteDuration,
+      count: Int
+  ): Stream[F, Unit] =
     program.handleErrorWith {
       case NonFatal(err) =>
         Stream.eval(Log[F].error(err) *> Log[F].info(s"Restarting in ${retry * count}...")) >>

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
@@ -85,7 +85,7 @@ class AMQPClientInMemory(
     Stream
       .eval(queues.get)
       .flatMap(_.find(_.value == queueName.value).fold(ifError) { _ =>
-        Stream.eval(ref.set(internals)).map(_ => "dequeue1 happens in AckerConsumerProgram.createConsumer")
+        Stream.eval(ref.set(internals)).as("dequeue1 happens in AckerConsumerProgram.createConsumer")
       })
   }
 

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -49,7 +49,8 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
       ssl = false,
       username = None,
       password = None,
-      requeueOnNack = false
+      requeueOnNack = false,
+      internalQueueSize = None
     )
 
   private val nackConfig =
@@ -61,7 +62,8 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
       ssl = false,
       username = None,
       password = None,
-      requeueOnNack = true
+      requeueOnNack = true,
+      internalQueueSize = None
     )
 
   /**
@@ -95,7 +97,8 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         amqpClient   = new AMQPClientInMemory(queues, exchanges, binds, queueRef, publishingQ, listenerQ, ackerQ, config)
         connStream   = new ConnectionStub
         acker        = new AckingProgram[IO](config, amqpClient)
-        consumer     = new ConsumingProgram[IO](amqpClient)
+        internalQ    = new InternalQueueStream[IO](config.internalQueueSize.getOrElse(500))
+        consumer     = new ConsumingProgram[IO](amqpClient, internalQ)
         fs2Rabbit    = new Fs2Rabbit[IO](config, connStream, amqpClient, acker, consumer)
         testSuiteRTS = rabbitRTS(queueRef, publishingQ)
       } yield (fs2Rabbit, testSuiteRTS)

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -97,7 +97,7 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         amqpClient   = new AMQPClientInMemory(queues, exchanges, binds, queueRef, publishingQ, listenerQ, ackerQ, config)
         connStream   = new ConnectionStub
         acker        = new AckingProgram[IO](config, amqpClient)
-        internalQ    = new InternalQueueStream[IO](config.internalQueueSize.getOrElse(500))
+        internalQ    = new LiveInternalQueue[IO](config.internalQueueSize.getOrElse(500))
         consumer     = new ConsumingProgram[IO](amqpClient, internalQ)
         fs2Rabbit    = new Fs2Rabbit[IO](config, connStream, amqpClient, acker, consumer)
         testSuiteRTS = rabbitRTS(queueRef, publishingQ)

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
@@ -32,7 +32,8 @@ object IOAckerConsumer extends IOApp {
     port = 5672,
     ssl = false,
     connectionTimeout = 3,
-    requeueOnNack = false
+    requeueOnNack = false,
+    internalQueueSize = Some(500)
   )
 
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -33,7 +33,8 @@ object MonixAutoAckConsumer extends TaskApp {
     port = 5672,
     ssl = false,
     connectionTimeout = 3,
-    requeueOnNack = false
+    requeueOnNack = false,
+    internalQueueSize = Some(500)
   )
 
   override def run(args: List[String]): Task[ExitCode] =

--- a/site/src/main/tut/config.md
+++ b/site/src/main/tut/config.md
@@ -19,6 +19,9 @@ val config = Fs2RabbitConfig(
   port = 5672,
   ssl = false,
   connectionTimeout = 3,
-  requeueOnNack = false
+  requeueOnNack = false,
+  internalQueueSize = Some(500)
 )
 ```
+
+The `internalQueueSize` indicates the size of the fs2's bounded queue used internally to communicate with the AMQP Java driver.

--- a/site/src/main/tut/examples/sample-acker.md
+++ b/site/src/main/tut/examples/sample-acker.md
@@ -59,7 +59,7 @@ class AckerConsumerDemo[F[_]: Concurrent](implicit F: Fs2Rabbit[F], SE: StreamEv
   private val queueName    = QueueName("testQ")
   private val exchangeName = ExchangeName("testEX")
   private val routingKey   = RoutingKey("testRK")
-  
+
   implicit val amqpMessageEncoder: MessageEncoder[F, AmqpMessage[String]] = Kleisli { msg =>
     msg.copy(payload = msg.payload.getBytes(UTF_8)).pure[F]
   }
@@ -104,7 +104,8 @@ object IOAckerConsumer extends IOApp {
     port = 5672,
     ssl = false,
     connectionTimeout = 3,
-    requeueOnNack = false
+    requeueOnNack = false,
+    internalQueueSize = Some(500)
   )
 
   override def run(args: List[String]): IO[ExitCode] =

--- a/site/src/main/tut/examples/sample-autoack.md
+++ b/site/src/main/tut/examples/sample-autoack.md
@@ -101,7 +101,8 @@ object MonixAutoAckConsumer extends TaskApp {
     port = 5672,
     ssl = false,
     connectionTimeout = 3,
-    requeueOnNack = false
+    requeueOnNack = false,
+    internalQueueSize = Some(500)
   )
 
   override def run(args: List[String]): Task[ExitCode] =

--- a/site/src/main/tut/interpreter.md
+++ b/site/src/main/tut/interpreter.md
@@ -45,7 +45,8 @@ class Demo extends IOApp {
     port = 5672,
     ssl = false,
     connectionTimeout = 3,
-    requeueOnNack = false
+    requeueOnNack = false,
+    internalQueueSize = Some(500)
   )
 
   override def run(args: List[String]): IO[ExitCode] =


### PR DESCRIPTION
Started by a [question](https://gitter.im/fs2-rabbit/fs2-rabbit?at=5bf50c60baf43f2b9b4d0e6a) asked by @ksonj on the Gitter channel about the differences between `algebras`, `programs` and `interpreters`, this PR now consolidates the idea by making it 100% consistent.

- Extracting effectful creation of bounded queue into different algebra and interpreter.
- Adding `internalQueueSize` config option.