### PR TITLE
Add attributes to AmqpEnvelope

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoder.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoder.scala
@@ -17,7 +17,7 @@
 package com.github.gvolpe.fs2rabbit.effects
 import cats.{Applicative, ApplicativeError}
 import cats.data.Kleisli
-import com.github.gvolpe.fs2rabbit.model.{AmqpHeaderVal, AmqpProperties}
+import com.github.gvolpe.fs2rabbit.model.{AmqpHeaderVal, AmqpProperties, ExchangeName, RoutingKey}
 import com.github.gvolpe.fs2rabbit.model.AmqpHeaderVal._
 import cats.implicits._
 
@@ -29,6 +29,15 @@ object EnvelopeDecoder {
 
   def payload[F[_]: Applicative]: EnvelopeDecoder[F, Array[Byte]] =
     Kleisli(_.payload.pure[F])
+
+  def routingKey[F[_]: Applicative]: EnvelopeDecoder[F, RoutingKey] =
+    Kleisli(e => e.routingKey.pure[F])
+
+  def exchangeName[F[_]: Applicative]: EnvelopeDecoder[F, ExchangeName] =
+    Kleisli(e => e.exchangeName.pure[F])
+
+  def redelivered[F[_]: Applicative]: EnvelopeDecoder[F, Boolean] =
+    Kleisli(e => e.redelivered.pure[F])
 
   def header[F[_]](name: String)(implicit F: ApplicativeError[F, Throwable]): EnvelopeDecoder[F, AmqpHeaderVal] =
     Kleisli(e => F.catchNonFatal(e.properties.headers(name)))

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
@@ -155,7 +155,12 @@ object model {
     }
   }
 
-  case class AmqpEnvelope[A](deliveryTag: DeliveryTag, payload: A, properties: AmqpProperties)
+  case class AmqpEnvelope[A](deliveryTag: DeliveryTag,
+                             payload: A,
+                             properties: AmqpProperties,
+                             exchangeName: ExchangeName,
+                             routingKey: RoutingKey,
+                             redelivered: Boolean)
   case class AmqpMessage[A](payload: A, properties: AmqpProperties)
 
   object AmqpEnvelope {

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoderSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/effects/EnvelopeDecoderSpec.scala
@@ -22,7 +22,7 @@ import cats.data.EitherT
 import cats.effect.{IO, SyncIO}
 import cats.instances.either._
 import cats.instances.try_._
-import com.github.gvolpe.fs2rabbit.model.{AmqpEnvelope, AmqpProperties, DeliveryTag}
+import com.github.gvolpe.fs2rabbit.model.{AmqpEnvelope, AmqpProperties, DeliveryTag, ExchangeName, RoutingKey}
 import org.scalatest.AsyncFunSuite
 
 import scala.util.Try
@@ -40,7 +40,8 @@ class EnvelopeDecoderSpec extends AsyncFunSuite {
     val raw = msg.getBytes(StandardCharsets.UTF_8)
 
     EnvelopeDecoder[IO, String]
-      .run(AmqpEnvelope(DeliveryTag(0L), raw, AmqpProperties.empty))
+      .run(
+        AmqpEnvelope(DeliveryTag(0L), raw, AmqpProperties.empty, ExchangeName("test"), RoutingKey("test.route"), false))
       .flatMap { result =>
         IO(assert(result == msg))
       }
@@ -52,7 +53,13 @@ class EnvelopeDecoderSpec extends AsyncFunSuite {
     val raw = msg.getBytes(StandardCharsets.UTF_8)
 
     EnvelopeDecoder[IO, String]
-      .run(AmqpEnvelope(DeliveryTag(0L), raw, AmqpProperties.empty.copy(contentEncoding = Some("UTF-16"))))
+      .run(
+        AmqpEnvelope(DeliveryTag(0L),
+                     raw,
+                     AmqpProperties.empty.copy(contentEncoding = Some("UTF-16")),
+                     ExchangeName("test"),
+                     RoutingKey("test.route"),
+                     false))
       .flatMap { result =>
         IO(assert(result != msg))
       }
@@ -64,7 +71,8 @@ class EnvelopeDecoderSpec extends AsyncFunSuite {
     val raw = msg.getBytes(StandardCharsets.UTF_16)
 
     EnvelopeDecoder[IO, String]
-      .run(AmqpEnvelope(DeliveryTag(0L), raw, AmqpProperties.empty))
+      .run(
+        AmqpEnvelope(DeliveryTag(0L), raw, AmqpProperties.empty, ExchangeName("test"), RoutingKey("test.route"), false))
       .flatMap { result =>
         IO(assert(result != msg))
       }

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientInMemory.scala
@@ -58,7 +58,12 @@ class AMQPClientInMemory(
       requeue: Boolean
   ): IO[Unit] = {
     // Imitating the RabbitMQ behavior
-    val envelope = AmqpEnvelope(DeliveryTag(1), "requeued msg".getBytes(UTF_8), AmqpProperties.empty)
+    val envelope = AmqpEnvelope(DeliveryTag(1),
+                                "requeued msg".getBytes(UTF_8),
+                                AmqpProperties.empty,
+                                ExchangeName("test"),
+                                RoutingKey("test.route"),
+                                false)
     for {
       _ <- ackerQ.enqueue1(NAck(tag))
       _ <- if (config.requeueOnNack) publishingQ.enqueue1(Right(envelope))
@@ -114,7 +119,7 @@ class AMQPClientInMemory(
       routingKey: model.RoutingKey,
       msg: model.AmqpMessage[Array[Byte]]
   ): IO[Unit] = {
-    val envelope = AmqpEnvelope(DeliveryTag(1), msg.payload, msg.properties)
+    val envelope = AmqpEnvelope(DeliveryTag(1), msg.payload, msg.properties, exchangeName, routingKey, false)
     publishingQ.enqueue1(Right(envelope))
   }
 

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -230,7 +230,12 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           ackResult <- Stream.eval(ackerQ.dequeue1)
         } yield {
           result should be(
-            AmqpEnvelope(DeliveryTag(1), "acker-test", AmqpProperties.empty.copy(contentEncoding = Some("UTF-8"))))
+            AmqpEnvelope(DeliveryTag(1),
+                         "acker-test",
+                         AmqpProperties.empty.copy(contentEncoding = Some("UTF-8")),
+                         exchangeName,
+                         routingKey,
+                         false))
           ackResult should be(Ack(DeliveryTag(1)))
         }
       }
@@ -253,7 +258,13 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         _                 <- (Stream(NAck(DeliveryTag(1))).covary[IO].observe(ackerQ.enqueue) evalMap acker).take(1)
         ackResult         <- Stream.eval(ackerQ.dequeue1)
       } yield {
-        result should be(AmqpEnvelope(DeliveryTag(1), "NAck-test", AmqpProperties(contentEncoding = Some("UTF-8"))))
+        result should be(
+          AmqpEnvelope(DeliveryTag(1),
+                       "NAck-test",
+                       AmqpProperties(contentEncoding = Some("UTF-8")),
+                       exchangeName,
+                       routingKey,
+                       false))
         ackResult should be(NAck(DeliveryTag(1)))
       }
     }
@@ -272,7 +283,13 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         _         <- Stream.eval(publisher("test"))
         result    <- consumer.take(1)
       } yield {
-        result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties(contentEncoding = Some("UTF-8"))))
+        result should be(
+          AmqpEnvelope(DeliveryTag(1),
+                       "test",
+                       AmqpProperties(contentEncoding = Some("UTF-8")),
+                       exchangeName,
+                       routingKey,
+                       false))
       }
     }
   }
@@ -296,7 +313,13 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           _      <- Stream.eval(publisher("test"))
           result <- consumer.take(1)
         } yield {
-          result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties(contentEncoding = Some("UTF-8"))))
+          result should be(
+            AmqpEnvelope(DeliveryTag(1),
+                         "test",
+                         AmqpProperties(contentEncoding = Some("UTF-8")),
+                         exchangeName,
+                         routingKey,
+                         false))
         }
       }
   }
@@ -328,7 +351,13 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
           result    <- Stream.eval(testQ.dequeue1)
           ackResult <- Stream.eval(ackerQ.dequeue1)
         } yield {
-          result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties(contentEncoding = Some("UTF-8"))))
+          result should be(
+            AmqpEnvelope(DeliveryTag(1),
+                         "test",
+                         AmqpProperties(contentEncoding = Some("UTF-8")),
+                         exchangeName,
+                         routingKey,
+                         false))
           ackResult should be(Ack(DeliveryTag(1)))
         }
       }
@@ -446,7 +475,13 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         result    <- Stream.eval(testQ.dequeue1)
         ackResult <- Stream.eval(ackerQ.dequeue1)
       } yield {
-        result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties(contentEncoding = Some("UTF-8"))))
+        result should be(
+          AmqpEnvelope(DeliveryTag(1),
+                       "test",
+                       AmqpProperties(contentEncoding = Some("UTF-8")),
+                       sourceExchangeName,
+                       routingKey,
+                       false))
         ackResult should be(Ack(DeliveryTag(1)))
       }
     }
@@ -511,7 +546,13 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         result    <- c1.take(1)
         rs2       <- takeWithTimeOut(c2, 1.second)
       } yield {
-        result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties(contentEncoding = Some("UTF-8"))))
+        result should be(
+          AmqpEnvelope(DeliveryTag(1),
+                       "test",
+                       AmqpProperties(contentEncoding = Some("UTF-8")),
+                       exchangeName,
+                       routingKey,
+                       false))
         rs2 should be(None)
       }
     }
@@ -558,7 +599,13 @@ class Fs2RabbitSpec extends FlatSpecLike with Matchers {
         _         <- msg.covary[IO] evalMap publisher(routingKey)
         result    <- consumer.take(1)
       } yield {
-        result should be(AmqpEnvelope(DeliveryTag(1), "test", AmqpProperties(contentEncoding = Some("UTF-8"))))
+        result should be(
+          AmqpEnvelope(DeliveryTag(1),
+                       "test",
+                       AmqpProperties(contentEncoding = Some("UTF-8")),
+                       exchangeName,
+                       routingKey,
+                       false))
       }
     }
   }


### PR DESCRIPTION
This exposes some additional attributes of the Java client library's [`Envelope`](https://rabbitmq.github.io/rabbitmq-java-client/api/current/com/rabbitmq/client/Envelope.html) on `AmqpEnvelope` (routing key, exchange name and the redelivery flag).

When having a consumer on a queue with multiple bindings, the routing key a message was routed with is often of interest (e.g. to identify the entity the message relates to).