### PR TITLE
Provide an option to configure multiple nodes of a cluster

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/config/Fs2RabbitConfig.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/config/Fs2RabbitConfig.scala
@@ -16,14 +16,46 @@
 
 package com.github.gvolpe.fs2rabbit.config
 
-case class Fs2RabbitConfig(
+import cats.data.NonEmptyList
+
+case class Fs2RabbitNodeConfig(
     host: String,
-    port: Int,
+    port: Int
+)
+
+case class Fs2RabbitConfig(
+    nodes: NonEmptyList[Fs2RabbitNodeConfig],
     virtualHost: String,
     connectionTimeout: Int,
     ssl: Boolean,
     username: Option[String],
     password: Option[String],
     requeueOnNack: Boolean,
-    internalQueueSize: Option[Int]
+    internalQueueSize: Option[Int],
+    automaticRecovery: Boolean
 )
+
+object Fs2RabbitConfig {
+  def apply(
+      host: String,
+      port: Int,
+      virtualHost: String,
+      connectionTimeout: Int,
+      ssl: Boolean,
+      username: Option[String],
+      password: Option[String],
+      requeueOnNack: Boolean,
+      internalQueueSize: Option[Int],
+      automaticRecovery: Boolean = true
+  ): Fs2RabbitConfig = Fs2RabbitConfig(
+    nodes = NonEmptyList.one(Fs2RabbitNodeConfig(host, port)),
+    virtualHost = virtualHost,
+    connectionTimeout = connectionTimeout,
+    ssl = ssl,
+    username = username,
+    password = password,
+    requeueOnNack = requeueOnNack,
+    internalQueueSize = internalQueueSize,
+    automaticRecovery = automaticRecovery
+  )
+}

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/IOAckerConsumer.scala
@@ -16,9 +16,10 @@
 
 package com.github.gvolpe.fs2rabbit.examples
 
+import cats.data.NonEmptyList
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.functor._
-import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
+import com.github.gvolpe.fs2rabbit.config.{Fs2RabbitConfig, Fs2RabbitNodeConfig}
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
 import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 
@@ -26,14 +27,19 @@ object IOAckerConsumer extends IOApp {
 
   private val config: Fs2RabbitConfig = Fs2RabbitConfig(
     virtualHost = "/",
-    host = "127.0.0.1",
+    nodes = NonEmptyList.one(
+      Fs2RabbitNodeConfig(
+        host = "127.0.0.1",
+        port = 5672
+      )
+    ),
     username = Some("guest"),
     password = Some("guest"),
-    port = 5672,
     ssl = false,
     connectionTimeout = 3,
     requeueOnNack = false,
-    internalQueueSize = Some(500)
+    internalQueueSize = Some(500),
+    automaticRecovery = true
   )
 
   override def run(args: List[String]): IO[ExitCode] =

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -16,9 +16,10 @@
 
 package com.github.gvolpe.fs2rabbit.examples
 
+import cats.data.NonEmptyList
 import cats.effect.ExitCode
 import cats.syntax.functor._
-import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
+import com.github.gvolpe.fs2rabbit.config.{Fs2RabbitConfig, Fs2RabbitNodeConfig}
 import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
 import com.github.gvolpe.fs2rabbit.resiliency.ResilientStream
 import monix.eval.{Task, TaskApp}
@@ -27,14 +28,19 @@ object MonixAutoAckConsumer extends TaskApp {
 
   private val config: Fs2RabbitConfig = Fs2RabbitConfig(
     virtualHost = "/",
-    host = "127.0.0.1",
+    nodes = NonEmptyList.one(
+      Fs2RabbitNodeConfig(
+        host = "127.0.0.1",
+        port = 5672
+      )
+    ),
     username = Some("guest"),
     password = Some("guest"),
-    port = 5672,
     ssl = false,
     connectionTimeout = 3,
     requeueOnNack = false,
-    internalQueueSize = Some(500)
+    internalQueueSize = Some(500),
+    automaticRecovery = true
   )
 
   override def run(args: List[String]): Task[ExitCode] =

--- a/site/src/main/tut/config.md
+++ b/site/src/main/tut/config.md
@@ -9,19 +9,26 @@ number: 1
 The main `RabbitMQ` configuration should be defined as `Fs2RabbitConfig`. You choose how to get the information, either from an `application.conf` file, from the environment or provided by an external system. A popular option that fits well the tech stack is [Pure Config](https://pureconfig.github.io/).
 
 ```tut:book:silent
-import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
+import cats.data.NonEmptyList
+import com.github.gvolpe.fs2rabbit.config.{Fs2RabbitConfig, Fs2RabbitNodeConfig}
 
 val config = Fs2RabbitConfig(
   virtualHost = "/",
-  host = "127.0.0.1",
+  nodes = NonEmptyList.one(
+    Fs2RabbitNodeConfig(
+      host = "127.0.0.1",
+      port = 5672
+    )
+  ),
   username = Some("guest"),
   password = Some("guest"),
-  port = 5672,
   ssl = false,
   connectionTimeout = 3,
   requeueOnNack = false,
-  internalQueueSize = Some(500)
+  internalQueueSize = Some(500),
+  automaticRecovery = true
 )
 ```
 
 The `internalQueueSize` indicates the size of the fs2's bounded queue used internally to communicate with the AMQP Java driver.
+The `automaticRecovery` indicates whether the AMQP Java driver should try to [recover broken connections](https://www.rabbitmq.com/api-guide.html#recovery).

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "1.0.0"
+version in ThisBuild := "1.1.0-SNAPSHOT"
 


### PR DESCRIPTION
Also expose the `automaticRecovery` option of `amqp-client`.

Fixes #155 .

Caveats:
- It's not really backwards compatible, since e.g. `pureconfig` does not recognize the new `apply` method with the old parameter list and also a `config.copy(port=1234)` wouldn't compile now, but compiled before.
- Since I used a `NonEmptyList`, `pureconfig` users would now also have to import `pureconfig-cats`. I can change it to use a normal `List`, if you prefer that @gvolpe .