### PR TITLE
Provide an option to allocate connection using cats.effect.Resource

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Connection.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Connection.scala
@@ -16,8 +16,9 @@
 
 package com.github.gvolpe.fs2rabbit.algebra
 
+import cats.effect.Resource
 import com.github.gvolpe.fs2rabbit.model.AMQPChannel
 
 trait Connection[F[_]] {
-  def createConnectionChannel: F[AMQPChannel]
+  def createConnectionChannel: Resource[F, AMQPChannel]
 }

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStub.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStub.scala
@@ -16,17 +16,15 @@
 
 package com.github.gvolpe.fs2rabbit.interpreter
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import com.github.gvolpe.fs2rabbit.algebra.Connection
 import com.github.gvolpe.fs2rabbit.model.AMQPChannel
-import com.github.gvolpe.fs2rabbit.effects.StreamEval
 import com.rabbitmq.client.Channel
-import fs2.Stream
 
-class ConnectionStub(implicit SE: StreamEval[IO]) extends Connection[Stream[IO, ?]] {
+class ConnectionStub extends Connection[IO] {
 
   case class ChannelStub(value: Channel = null) extends AMQPChannel
 
-  override def createConnectionChannel: Stream[IO, AMQPChannel] = SE.pure(ChannelStub())
+  override def createConnectionChannel: Resource[IO, AMQPChannel] = Resource.pure(ChannelStub())
 
 }


### PR DESCRIPTION
Hi @gvolpe ,

from my perspective, `cats.effect.Resource` can be used to manage the AMQP connection. This change provides more flexible API. 

I have one open question about my PR: personally, I don't like names of methods in my pull request. `createConnectionChannelResource` doesn't look good for me.

Probably, it wiill be better to expose connectionBuilder as a part of public Fs2Rabbit API.
Then naming will be much more clear and obvious:
```scala
for {
  rabbit <- Fs2Rabbit(config)
  _ <- rabbit.connectionBuilder.resource.use(channel => effectProgram.apply(channel)) 
 // or
  _ <- ResilientStream.run(rabbit.connectionBuilder.stream.flatMap(channel => streamProgram.apply(channel)))
} yield ExitCode.Success
```

What do you think?