### PR TITLE
Spinning a single Docker instance per suite + polishing tests

### DIFF
--- a/test-support/src/main/scala/com/github/gvolpe/fs2rabbit/DockerRabbit.scala
+++ b/test-support/src/main/scala/com/github/gvolpe/fs2rabbit/DockerRabbit.scala
@@ -38,7 +38,7 @@ trait DockerRabbit extends BeforeAndAfterAll { self: Suite =>
 
   private var dockerInstanceId: Option[String] = None
 
-  implicit val cts: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -53,7 +53,7 @@ trait DockerRabbit extends BeforeAndAfterAll { self: Suite =>
     dockerInstanceId.foreach(stopDocker)
   }
 
-  protected lazy val rabbitConfig = Fs2RabbitConfig(
+  lazy val rabbitConfig = Fs2RabbitConfig(
     host = "localhost",
     port = rabbitPort,
     virtualHost = rabbitVirtualHost,

--- a/tests/src/test/scala/com/github/gvolpe/fs2rabbit/BaseSpec.scala
+++ b/tests/src/test/scala/com/github/gvolpe/fs2rabbit/BaseSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2019 Fs2 Rabbit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.fs2rabbit
+
+import cats.effect.{ContextShift, IO, Timer}
+import com.github.gvolpe.fs2rabbit.effects.Log
+import org.scalatest.{EitherValues, FlatSpecLike, Matchers}
+
+import scala.concurrent.ExecutionContext
+
+trait BaseSpec extends FlatSpecLike with Matchers with EitherValues {
+  def putStrLn[A](a: A): IO[Unit] = IO(println(a))
+
+  implicit val timer: Timer[IO]     = IO.timer(ExecutionContext.global)
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  implicit val logger: Log[IO] = new Log[IO] {
+    override def info(value: String): IO[Unit]     = putStrLn(value)
+    override def error(error: Throwable): IO[Unit] = putStrLn(error.getMessage)
+  }
+}

--- a/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStreamSpec.scala
+++ b/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/ConnectionStreamSpec.scala
@@ -18,11 +18,13 @@ package com.github.gvolpe.fs2rabbit.interpreter
 
 import cats.effect.IO
 import cats.syntax.functor._
+import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.model.AMQPChannel
-import com.github.gvolpe.fs2rabbit.{DockerRabbit, IOAssertion}
-import org.scalatest.{FlatSpec, Matchers}
+import com.github.gvolpe.fs2rabbit.{BaseSpec, IOAssertion}
 
-class ConnectionStreamSpec extends FlatSpec with Matchers with DockerRabbit {
+trait ConnectionStreamSpec { self: BaseSpec =>
+
+  def config: Fs2RabbitConfig
 
   "ConnectionStream" should "create and close connection using bracket" in IOAssertion {
     def openAssertion(channel: AMQPChannel) =
@@ -32,7 +34,7 @@ class ConnectionStreamSpec extends FlatSpec with Matchers with DockerRabbit {
       }.void
 
     for {
-      rabbit     <- Fs2Rabbit[IO](rabbitConfig)
+      rabbit     <- Fs2Rabbit[IO](config)
       connection <- rabbit.createConnectionChannel.evalTap(openAssertion).compile.lastOrError
     } yield {
       assert(!connection.value.isOpen, "Channel should be closed")

--- a/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -17,33 +17,32 @@
 package com.github.gvolpe.fs2rabbit.interpreter
 
 import cats.effect.concurrent.Deferred
-import cats.effect.{IO, Timer}
+import cats.effect.IO
+import cats.syntax.apply._
 import cats.syntax.option._
+import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 import com.github.gvolpe.fs2rabbit.config.declaration._
 import com.github.gvolpe.fs2rabbit.config.deletion.{DeletionExchangeConfig, DeletionQueueConfig}
 import com.github.gvolpe.fs2rabbit.model.AckResult.{Ack, NAck}
 import com.github.gvolpe.fs2rabbit.model._
-import com.github.gvolpe.fs2rabbit.{DockerRabbit, IOAssertion, model}
+import com.github.gvolpe.fs2rabbit.{BaseSpec, IOAssertion, model}
 import fs2.Stream
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Random
 
-class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with EitherValues {
+trait Fs2RabbitSpec { self: BaseSpec =>
 
-  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  def config: Fs2RabbitConfig
 
   it should "create a connection and a queue with default arguments" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, _) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _ <- declareExchange(exchangeName, ExchangeType.Topic)
+        (q, x, _) <- Stream.eval(randomQueueData)
+        _         <- declareQueue(DeclarationQueueConfig.default(q))
+        _         <- declareExchange(x, ExchangeType.Topic)
       } yield ()
     }
   }
@@ -51,12 +50,11 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create a connection and a queue with options enabled" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, _) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareQueue(DeclarationQueueConfig(queueName, Durable, Exclusive, AutoDelete, Map.empty))
-        _ <- declareExchange(exchangeName, ExchangeType.Topic)
+        (q, x, _) <- Stream.eval(randomQueueData)
+        _         <- declareQueue(DeclarationQueueConfig(q, Durable, Exclusive, AutoDelete, Map.empty))
+        _         <- declareExchange(x, ExchangeType.Topic)
       } yield ()
     }
   }
@@ -64,12 +62,11 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create a connection and a queue (no wait)" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, _) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareQueueNoWait(DeclarationQueueConfig.default(queueName))
-        _ <- declareExchange(exchangeName, ExchangeType.Topic)
+        (q, x, _) <- Stream.eval(randomQueueData)
+        _         <- declareQueueNoWait(DeclarationQueueConfig.default(q))
+        _         <- declareExchange(x, ExchangeType.Topic)
       } yield ()
     }
   }
@@ -77,12 +74,11 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create a connection and a passive queue" in withRabbit { interpreter =>
     import interpreter._
 
-    val queueName = QueueName(randomString())
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _ <- declareQueuePassive(queueName)
+        q <- Stream.eval(mkRandomString.map(QueueName))
+        _ <- declareQueue(DeclarationQueueConfig.default(q))
+        _ <- declareQueuePassive(q)
       } yield ()
     }
   }
@@ -90,9 +86,10 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "return an error during creation of a passive queue if queue doesn't exist" in withRabbit { interpreter =>
     import interpreter._
 
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        result <- declareQueuePassive(QueueName(randomString())).attempt
+        queue  <- Stream.eval(mkRandomString.map(QueueName))
+        result <- declareQueuePassive(queue).attempt
       } yield {
         result.left.value shouldBe a[java.io.IOException]
       }
@@ -103,9 +100,10 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
     interpreter =>
       import interpreter._
 
-      createConnectionChannel flatMap { implicit channel =>
+      createConnectionChannel.flatMap { implicit channel =>
         for {
-          result <- declareExchangePassive(ExchangeName(randomString())).attempt
+          exchange <- Stream.eval(mkRandomString.map(ExchangeName))
+          result   <- declareExchangePassive(exchange).attempt
         } yield {
           result.left.value shouldBe a[java.io.IOException]
         }
@@ -115,12 +113,11 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create a connection and an exchange" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, _) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _ <- declareExchange(exchangeName, ExchangeType.Topic)
+        (q, x, _) <- Stream.eval(randomQueueData)
+        _         <- declareQueue(DeclarationQueueConfig.default(q))
+        _         <- declareExchange(x, ExchangeType.Topic)
       } yield ()
     }
   }
@@ -128,12 +125,11 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create a connection and an exchange (no wait)" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, _) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _ <- declareExchangeNoWait(DeclarationExchangeConfig.default(exchangeName, ExchangeType.Topic))
+        (q, x, _) <- Stream.eval(randomQueueData)
+        _         <- declareQueue(DeclarationQueueConfig.default(q))
+        _         <- declareExchangeNoWait(DeclarationExchangeConfig.default(x, ExchangeType.Topic))
       } yield ()
     }
   }
@@ -141,12 +137,11 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create a connection and declare an exchange passively" in withRabbit { interpreter =>
     import interpreter._
 
-    val (_, exchangeName, _) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareExchange(exchangeName, ExchangeType.Topic)
-        _ <- declareExchangePassive(exchangeName)
+        exchange <- Stream.eval(mkRandomString.map(ExchangeName))
+        _        <- declareExchange(exchange, ExchangeType.Topic)
+        _        <- declareExchangePassive(exchange)
       } yield ()
     }
   }
@@ -154,14 +149,14 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "return an error as the result of 'basicCancel' if consumer doesn't exist" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _      <- declareExchange(exchangeName, ExchangeType.Topic)
-        _      <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _      <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty))
-        result <- Stream.eval(basicCancel(ConsumerTag(randomString()))).attempt.take(1)
+        (q, x, rk) <- Stream.eval(randomQueueData)
+        _          <- declareExchange(x, ExchangeType.Topic)
+        _          <- declareQueue(DeclarationQueueConfig.default(q))
+        _          <- bindQueue(q, x, rk, QueueBindingArgs(Map.empty))
+        ct         <- Stream.eval(mkRandomString.map(ConsumerTag))
+        result     <- Stream.eval(basicCancel(ct)).attempt.take(1)
       } yield {
         result.left.value shouldBe a[java.io.IOException]
       }
@@ -171,21 +166,19 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create an acker consumer and verify both envelope and ack result" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _                 <- declareExchange(exchangeName, ExchangeType.Topic)
-        _                 <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _                 <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty))
-        publisher         <- createPublisher[String](exchangeName, routingKey)
+        (q, x, rk)        <- Stream.eval(randomQueueData)
+        _                 <- declareExchange(x, ExchangeType.Topic)
+        _                 <- declareQueue(DeclarationQueueConfig.default(q))
+        _                 <- bindQueue(q, x, rk, QueueBindingArgs(Map.empty))
+        publisher         <- createPublisher[String](x, rk)
         _                 <- Stream.eval(publisher("acker-test"))
-        ackerConsumer     <- createAckerConsumer(queueName)
-        (acker, consumer) = ackerConsumer
+        (acker, consumer) <- createAckerConsumer(q)
         result            <- consumer.take(1)
         _                 <- Stream.eval(acker(Ack(result.deliveryTag)))
       } yield {
-        result shouldBe expectedDelivery(result.deliveryTag, exchangeName, routingKey, "acker-test")
+        result shouldBe expectedDelivery(result.deliveryTag, x, rk, "acker-test")
       }
     }
   }
@@ -193,21 +186,19 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "NOT requeue a message in case of NAck when option 'requeueOnNack = false'" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _                 <- declareExchange(exchangeName, ExchangeType.Topic)
-        _                 <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _                 <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty))
-        publisher         <- createPublisher[String](exchangeName, routingKey)
+        (q, x, rk)        <- Stream.eval(randomQueueData)
+        _                 <- declareExchange(x, ExchangeType.Topic)
+        _                 <- declareQueue(DeclarationQueueConfig.default(q))
+        _                 <- bindQueue(q, x, rk, QueueBindingArgs(Map.empty))
+        publisher         <- createPublisher[String](x, rk)
         _                 <- Stream.eval(publisher("NAck-test"))
-        ackerConsumer     <- createAckerConsumer(queueName)
-        (acker, consumer) = ackerConsumer
+        (acker, consumer) <- createAckerConsumer(q)
         result            <- consumer.take(1)
         _                 <- Stream.eval(acker(NAck(result.deliveryTag)))
       } yield {
-        result shouldBe expectedDelivery(result.deliveryTag, exchangeName, routingKey, "NAck-test")
+        result shouldBe expectedDelivery(result.deliveryTag, x, rk, "NAck-test")
       }
     }
   }
@@ -215,19 +206,18 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create a publisher, an auto-ack consumer, publish a message and consume it" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _         <- declareExchange(exchangeName, ExchangeType.Topic)
-        _         <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _         <- bindQueue(queueName, exchangeName, routingKey)
-        publisher <- createPublisher[String](exchangeName, routingKey)
-        consumer  <- createAutoAckConsumer(queueName)
-        _         <- Stream.eval(publisher("test"))
-        result    <- consumer.take(1)
+        (q, x, rk) <- Stream.eval(randomQueueData)
+        _          <- declareExchange(x, ExchangeType.Topic)
+        _          <- declareQueue(DeclarationQueueConfig.default(q))
+        _          <- bindQueue(q, x, rk)
+        publisher  <- createPublisher[String](x, rk)
+        consumer   <- createAutoAckConsumer(q)
+        _          <- Stream.eval(publisher("test"))
+        result     <- consumer.take(1)
       } yield {
-        result shouldBe expectedDelivery(result.deliveryTag, exchangeName, routingKey, "test")
+        result shouldBe expectedDelivery(result.deliveryTag, x, rk, "test")
       }
     }
   }
@@ -235,21 +225,20 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create an exclusive auto-ack consumer with specific BasicQos" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-    val consumerTag                           = ConsumerTag(randomString())
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _            <- declareExchange(exchangeName, ExchangeType.Topic)
-        _            <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _            <- bindQueue(queueName, exchangeName, routingKey)
-        publisher    <- createPublisher[String](exchangeName, routingKey)
-        consumerArgs = ConsumerArgs(consumerTag = consumerTag, noLocal = false, exclusive = true, args = Map.empty)
-        consumer     <- createAutoAckConsumer(queueName, BasicQos(prefetchSize = 0, prefetchCount = 10), Some(consumerArgs))
+        (q, x, rk)   <- Stream.eval(randomQueueData)
+        ct           <- Stream.eval(mkRandomString.map(ConsumerTag))
+        _            <- declareExchange(x, ExchangeType.Topic)
+        _            <- declareQueue(DeclarationQueueConfig.default(q))
+        _            <- bindQueue(q, x, rk)
+        publisher    <- createPublisher[String](x, rk)
+        consumerArgs = ConsumerArgs(consumerTag = ct, noLocal = false, exclusive = true, args = Map.empty)
+        consumer     <- createAutoAckConsumer(q, BasicQos(prefetchSize = 0, prefetchCount = 10), Some(consumerArgs))
         _            <- Stream.eval(publisher("test"))
         result       <- consumer.take(1)
       } yield {
-        result shouldBe expectedDelivery(result.deliveryTag, exchangeName, routingKey, "test")
+        result shouldBe expectedDelivery(result.deliveryTag, x, rk, "test")
       }
     }
   }
@@ -257,25 +246,21 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "create an exclusive acker consumer with specific BasicQos" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-    val consumerTag                           = ConsumerTag(randomString())
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _            <- declareExchange(exchangeName, ExchangeType.Topic)
-        _            <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _            <- bindQueue(queueName, exchangeName, routingKey)
-        publisher    <- createPublisher[String](exchangeName, routingKey)
-        consumerArgs = ConsumerArgs(consumerTag = consumerTag, noLocal = false, exclusive = true, args = Map.empty)
-        ackerConsumer <- createAckerConsumer(queueName,
-                                             BasicQos(prefetchSize = 0, prefetchCount = 10),
-                                             Some(consumerArgs))
-        (acker, consumer) = ackerConsumer
+        (q, x, rk)        <- Stream.eval(randomQueueData)
+        ct                <- Stream.eval(mkRandomString.map(ConsumerTag))
+        _                 <- declareExchange(x, ExchangeType.Topic)
+        _                 <- declareQueue(DeclarationQueueConfig.default(q))
+        _                 <- bindQueue(q, x, rk)
+        publisher         <- createPublisher[String](x, rk)
+        consumerArgs      = ConsumerArgs(consumerTag = ct, noLocal = false, exclusive = true, args = Map.empty)
+        (acker, consumer) <- createAckerConsumer(q, BasicQos(prefetchSize = 0, prefetchCount = 10), Some(consumerArgs))
         _                 <- Stream.eval(publisher("test"))
         result            <- consumer.take(1)
         _                 <- Stream.eval(acker(Ack(result.deliveryTag)))
       } yield {
-        result shouldBe expectedDelivery(result.deliveryTag, exchangeName, routingKey, "test")
+        result shouldBe expectedDelivery(result.deliveryTag, x, rk, "test")
       }
     }
   }
@@ -283,13 +268,12 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "bind a queue with the nowait parameter set to true" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareExchange(exchangeName, ExchangeType.Topic)
-        _ <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _ <- bindQueueNoWait(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty))
+        (q, x, rk) <- Stream.eval(randomQueueData)
+        _          <- declareExchange(x, ExchangeType.Topic)
+        _          <- declareQueue(DeclarationQueueConfig.default(q))
+        _          <- bindQueueNoWait(q, x, rk, QueueBindingArgs(Map.empty))
       } yield ()
     }
   }
@@ -297,16 +281,15 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "try to delete a queue twice (only first time should be okay)" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, _) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _        <- declareExchange(exchangeName, ExchangeType.Direct)
-        _        <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _        <- deleteQueue(DeletionQueueConfig.default(queueName))
-        _        <- deleteQueueNoWait(DeletionQueueConfig.default(queueName))
-        consumer <- createAutoAckConsumer(queueName)
-        either   <- consumer.attempt.take(1)
+        (q, x, _) <- Stream.eval(randomQueueData)
+        _         <- declareExchange(x, ExchangeType.Direct)
+        _         <- declareQueue(DeclarationQueueConfig.default(q))
+        _         <- deleteQueue(DeletionQueueConfig.default(q))
+        _         <- deleteQueueNoWait(DeletionQueueConfig.default(q))
+        consumer  <- createAutoAckConsumer(q)
+        either    <- consumer.attempt.take(1)
       } yield {
         either shouldBe a[Left[_, _]]
         either.left.value shouldBe a[java.io.IOException]
@@ -317,12 +300,11 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "delete an exchange successfully" in withRabbit { interpreter =>
     import interpreter._
 
-    val (_, exchangeName, _) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _      <- declareExchange(exchangeName, ExchangeType.Direct)
-        either <- deleteExchangeNoWait(DeletionExchangeConfig.default(exchangeName)).attempt.take(1)
+        exchange <- Stream.eval(mkRandomString.map(ExchangeName))
+        _        <- declareExchange(exchange, ExchangeType.Direct)
+        either   <- deleteExchangeNoWait(DeletionExchangeConfig.default(exchange)).attempt.take(1)
       } yield {
         either shouldBe a[Right[_, _]]
       }
@@ -332,13 +314,12 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "try to unbind a queue when there is no binding" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareExchange(exchangeName, ExchangeType.Direct)
-        _ <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _ <- unbindQueue(queueName, exchangeName, routingKey)
+        (q, x, rk) <- Stream.eval(randomQueueData)
+        _          <- declareExchange(x, ExchangeType.Direct)
+        _          <- declareQueue(DeclarationQueueConfig.default(q))
+        _          <- unbindQueue(q, x, rk)
       } yield ()
     }
   }
@@ -346,14 +327,13 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "unbind a queue" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareExchange(exchangeName, ExchangeType.Direct)
-        _ <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _ <- bindQueue(queueName, exchangeName, routingKey)
-        _ <- unbindQueue(queueName, exchangeName, routingKey)
+        (q, x, rk) <- Stream.eval(randomQueueData)
+        _          <- declareExchange(x, ExchangeType.Direct)
+        _          <- declareQueue(DeclarationQueueConfig.default(q))
+        _          <- bindQueue(q, x, rk)
+        _          <- unbindQueue(q, x, rk)
       } yield ()
     }
   }
@@ -361,29 +341,25 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "bind an exchange to another exchange" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, _, routingKey) = randomQueueData()
-    val sourceExchangeName         = ExchangeName(randomString())
-    val destinationExchangeName    = ExchangeName(randomString())
-    val consumerTag                = ConsumerTag(randomString())
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _            <- declareExchange(sourceExchangeName, ExchangeType.Direct)
-        _            <- declareExchange(destinationExchangeName, ExchangeType.Direct)
-        _            <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _            <- bindQueue(queueName, destinationExchangeName, routingKey)
-        _            <- bindExchange(destinationExchangeName, sourceExchangeName, routingKey, ExchangeBindingArgs(Map.empty))
-        publisher    <- createPublisher[String](sourceExchangeName, routingKey)
-        consumerArgs = ConsumerArgs(consumerTag = consumerTag, noLocal = false, exclusive = true, args = Map.empty)
-        ackerConsumer <- createAckerConsumer(queueName,
-                                             BasicQos(prefetchSize = 0, prefetchCount = 10),
-                                             Some(consumerArgs))
-        (acker, consumer) = ackerConsumer
+        (q, _, rk)        <- Stream.eval(randomQueueData)
+        sourceExchange    <- Stream.eval(mkRandomString.map(ExchangeName))
+        destExchange      <- Stream.eval(mkRandomString.map(ExchangeName))
+        consumerTag       <- Stream.eval(mkRandomString.map(ConsumerTag))
+        _                 <- declareExchange(sourceExchange, ExchangeType.Direct)
+        _                 <- declareExchange(destExchange, ExchangeType.Direct)
+        _                 <- declareQueue(DeclarationQueueConfig.default(q))
+        _                 <- bindQueue(q, destExchange, rk)
+        _                 <- bindExchange(destExchange, sourceExchange, rk, ExchangeBindingArgs(Map.empty))
+        publisher         <- createPublisher[String](sourceExchange, rk)
+        consumerArgs      = ConsumerArgs(consumerTag = consumerTag, noLocal = false, exclusive = true, args = Map.empty)
+        (acker, consumer) <- createAckerConsumer(q, BasicQos(prefetchSize = 0, prefetchCount = 10), Some(consumerArgs))
         _                 <- Stream.eval(publisher("test"))
         receivedMessage   <- consumer.take(1)
         _                 <- Stream.eval(acker(Ack(receivedMessage.deliveryTag)))
       } yield {
-        receivedMessage shouldBe expectedDelivery(receivedMessage.deliveryTag, sourceExchangeName, routingKey, "test")
+        receivedMessage shouldBe expectedDelivery(receivedMessage.deliveryTag, sourceExchange, rk, "test")
       }
     }
   }
@@ -391,16 +367,15 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "unbind an exchange" in withRabbit { interpreter =>
     import interpreter._
 
-    val (_, _, routingKey)      = randomQueueData()
-    val sourceExchangeName      = ExchangeName(randomString())
-    val destinationExchangeName = ExchangeName(randomString())
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _ <- declareExchange(sourceExchangeName, ExchangeType.Direct)
-        _ <- declareExchange(destinationExchangeName, ExchangeType.Direct)
-        _ <- bindExchange(destinationExchangeName, sourceExchangeName, routingKey)
-        _ <- unbindExchange(destinationExchangeName, sourceExchangeName, routingKey)
+        rk             <- Stream.eval(mkRandomString.map(RoutingKey))
+        sourceExchange <- Stream.eval(mkRandomString.map(ExchangeName))
+        destExchange   <- Stream.eval(mkRandomString.map(ExchangeName))
+        _              <- declareExchange(sourceExchange, ExchangeType.Direct)
+        _              <- declareExchange(destExchange, ExchangeType.Direct)
+        _              <- bindExchange(destExchange, sourceExchange, rk)
+        _              <- unbindExchange(destExchange, sourceExchange, rk)
       } yield ()
     }
   }
@@ -408,22 +383,20 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "requeue a message in case of NAck when option 'requeueOnNack = true'" in withNackRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-
-    createConnectionChannel flatMap { implicit channel =>
+    createConnectionChannel.flatMap { implicit channel =>
       for {
-        _                 <- declareExchange(exchangeName, ExchangeType.Topic)
-        _                 <- declareQueue(DeclarationQueueConfig.default(queueName))
-        _                 <- bindQueue(queueName, exchangeName, routingKey, QueueBindingArgs(Map.empty))
-        publisher         <- createPublisher[String](exchangeName, routingKey)
+        (q, x, rk)        <- Stream.eval(randomQueueData)
+        _                 <- declareExchange(x, ExchangeType.Topic)
+        _                 <- declareQueue(DeclarationQueueConfig.default(q))
+        _                 <- bindQueue(q, x, rk, QueueBindingArgs(Map.empty))
+        publisher         <- createPublisher[String](x, rk)
         _                 <- Stream.eval(publisher("NAck-test"))
-        ackerConsumer     <- createAckerConsumer(queueName)
-        (acker, consumer) = ackerConsumer
+        (acker, consumer) <- createAckerConsumer(q)
         result            <- Stream.eval(consumer.take(1).compile.lastOrError)
         _                 <- Stream.eval(acker(NAck(result.deliveryTag)))
-        result2           <- createAutoAckConsumer(queueName).flatten.take(1) // Message will be re-queued
+        result2           <- createAutoAckConsumer(q).flatten.take(1) // Message will be re-queued
       } yield {
-        val expected = expectedDelivery(result.deliveryTag, exchangeName, routingKey, "NAck-test")
+        val expected = expectedDelivery(result.deliveryTag, x, rk, "NAck-test")
 
         result shouldBe expected
         result2 shouldBe expected.copy(deliveryTag = result2.deliveryTag, redelivered = true)
@@ -435,24 +408,23 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
     interpreter =>
       import interpreter._
 
-      val (queueName, exchangeName, routingKey) = randomQueueData()
-      val diffQ                                 = QueueName(randomString())
-
-      createConnectionChannel flatMap { implicit channel =>
+      createConnectionChannel.flatMap { implicit channel =>
         for {
-          _         <- declareExchange(exchangeName, ExchangeType.Topic)
-          publisher <- createPublisher[String](exchangeName, routingKey)
-          _         <- declareQueue(DeclarationQueueConfig.default(queueName))
-          _         <- bindQueue(queueName, exchangeName, routingKey)
-          _         <- declareQueue(DeclarationQueueConfig.default(diffQ))
-          _         <- bindQueue(queueName, exchangeName, RoutingKey("diffRK"))
-          c1        <- createAutoAckConsumer(queueName)
-          c2        <- createAutoAckConsumer(diffQ)
-          _         <- Stream.eval(publisher("test"))
-          result    <- c1.take(1)
-          rs2       <- takeWithTimeOut(c2, 1.second)
+          (q, x, rk) <- Stream.eval(randomQueueData)
+          diffQ      <- Stream.eval(mkRandomString.map(QueueName))
+          _          <- declareExchange(x, ExchangeType.Topic)
+          publisher  <- createPublisher[String](x, rk)
+          _          <- declareQueue(DeclarationQueueConfig.default(q))
+          _          <- bindQueue(q, x, rk)
+          _          <- declareQueue(DeclarationQueueConfig.default(diffQ))
+          _          <- bindQueue(q, x, RoutingKey("diffRK"))
+          c1         <- createAutoAckConsumer(q)
+          c2         <- createAutoAckConsumer(diffQ)
+          _          <- Stream.eval(publisher("test"))
+          result     <- c1.take(1)
+          rs2        <- takeWithTimeOut(c2, 1.second)
         } yield {
-          result shouldBe expectedDelivery(result.deliveryTag, exchangeName, routingKey, "test")
+          result shouldBe expectedDelivery(result.deliveryTag, x, rk, "test")
           rs2 shouldBe None
         }
       }
@@ -462,20 +434,20 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
     interpreter =>
       import interpreter._
 
-      val (queueName, exchangeName, routingKey) = randomQueueData()
-      val flag                                  = PublishingFlag(mandatory = true)
+      val flag = PublishingFlag(mandatory = true)
 
-      createConnectionChannel flatMap { implicit channel =>
+      createConnectionChannel.flatMap { implicit channel =>
         for {
-          _         <- declareExchange(exchangeName, ExchangeType.Topic)
-          _         <- declareQueue(DeclarationQueueConfig.default(queueName))
-          _         <- bindQueue(queueName, exchangeName, routingKey)
-          promise   <- Stream.eval(Deferred[IO, PublishReturn])
-          publisher <- createPublisherWithListener(exchangeName, RoutingKey("diff-rk"), flag, listener(promise))
-          consumer  <- createAutoAckConsumer(queueName)
-          _         <- Stream.eval(publisher("test"))
-          callback  <- Stream.eval(promise.get.map(_.some).timeoutTo(500.millis, IO.pure(none[PublishReturn]))).unNone
-          result    <- takeWithTimeOut(consumer, 500.millis)
+          (q, x, rk) <- Stream.eval(randomQueueData)
+          _          <- declareExchange(x, ExchangeType.Topic)
+          _          <- declareQueue(DeclarationQueueConfig.default(q))
+          _          <- bindQueue(q, x, rk)
+          promise    <- Stream.eval(Deferred[IO, PublishReturn])
+          publisher  <- createPublisherWithListener(x, RoutingKey("diff-rk"), flag, listener(promise))
+          consumer   <- createAutoAckConsumer(q)
+          _          <- Stream.eval(publisher("test"))
+          callback   <- Stream.eval(promise.get.map(_.some).timeoutTo(500.millis, IO.pure(none[PublishReturn]))).unNone
+          result     <- takeWithTimeOut(consumer, 500.millis)
         } yield {
           result shouldBe None
           callback.body.value shouldEqual "test".getBytes("UTF-8")
@@ -488,19 +460,18 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
     interpreter =>
       import interpreter._
 
-      val (queueName, exchangeName, routingKey) = randomQueueData()
-
-      createConnectionChannel flatMap { implicit channel =>
+      createConnectionChannel.flatMap { implicit channel =>
         for {
-          _         <- declareExchange(exchangeName, ExchangeType.Topic)
-          _         <- declareQueue(DeclarationQueueConfig.default(queueName))
-          _         <- bindQueue(queueName, exchangeName, routingKey)
-          publisher <- createRoutingPublisher[String](exchangeName)
-          consumer  <- createAutoAckConsumer(queueName)
-          _         <- Stream.eval(publisher(routingKey).apply("test"))
-          result    <- consumer.take(1)
+          (q, x, rk) <- Stream.eval(randomQueueData)
+          _          <- declareExchange(x, ExchangeType.Topic)
+          _          <- declareQueue(DeclarationQueueConfig.default(q))
+          _          <- bindQueue(q, x, rk)
+          publisher  <- createRoutingPublisher[String](x)
+          consumer   <- createAutoAckConsumer(q)
+          _          <- Stream.eval(publisher(rk).apply("test"))
+          result     <- consumer.take(1)
         } yield {
-          result shouldBe expectedDelivery(result.deliveryTag, exchangeName, routingKey, "test")
+          result shouldBe expectedDelivery(result.deliveryTag, x, rk, "test")
         }
       }
   }
@@ -509,20 +480,20 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
     interpreter =>
       import interpreter._
 
-      val (queueName, exchangeName, routingKey) = randomQueueData()
-      val flag                                  = PublishingFlag(mandatory = true)
+      val flag = PublishingFlag(mandatory = true)
 
-      createConnectionChannel flatMap { implicit channel =>
+      createConnectionChannel.flatMap { implicit channel =>
         for {
-          _         <- declareExchange(exchangeName, ExchangeType.Topic)
-          _         <- declareQueue(DeclarationQueueConfig.default(queueName))
-          _         <- bindQueue(queueName, exchangeName, routingKey)
-          promise   <- Stream.eval(Deferred[IO, PublishReturn])
-          publisher <- createRoutingPublisherWithListener[String](exchangeName, flag, listener(promise))
-          consumer  <- createAutoAckConsumer(queueName)
-          _         <- Stream.eval(publisher(RoutingKey("diff-rk"))("test"))
-          callback  <- Stream.eval(promise.get.map(_.some).timeoutTo(500.millis, IO.pure(none[PublishReturn]))).unNone
-          result    <- takeWithTimeOut(consumer, 500.millis)
+          (q, x, rk) <- Stream.eval(randomQueueData)
+          _          <- declareExchange(x, ExchangeType.Topic)
+          _          <- declareQueue(DeclarationQueueConfig.default(q))
+          _          <- bindQueue(q, x, rk)
+          promise    <- Stream.eval(Deferred[IO, PublishReturn])
+          publisher  <- createRoutingPublisherWithListener[String](x, flag, listener(promise))
+          consumer   <- createAutoAckConsumer(q)
+          _          <- Stream.eval(publisher(RoutingKey("diff-rk"))("test"))
+          callback   <- Stream.eval(promise.get.map(_.some).timeoutTo(500.millis, IO.pure(none[PublishReturn]))).unNone
+          result     <- takeWithTimeOut(consumer, 500.millis)
         } yield {
           result shouldBe None
           callback.body.value shouldEqual "test".getBytes("UTF-8")
@@ -534,57 +505,54 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
   it should "consume published message" in withRabbit { interpreter =>
     import interpreter._
 
-    val (queueName, exchangeName, routingKey) = randomQueueData()
-
     val message = "Test text here"
 
-    val consumer: Stream[IO, model.AmqpEnvelope[String]] =
+    def consumer(q: QueueName, x: ExchangeName, rk: RoutingKey): Stream[IO, model.AmqpEnvelope[String]] =
       createConnectionChannel flatMap { implicit channel =>
         for {
-          _        <- declareQueue(DeclarationQueueConfig.default(queueName))
-          _        <- declareExchange(exchangeName, ExchangeType.Topic)
-          _        <- bindQueue(queueName, exchangeName, routingKey)
-          consumer <- createAutoAckConsumer[String](queueName)
+          _        <- declareQueue(DeclarationQueueConfig.default(q))
+          _        <- declareExchange(x, ExchangeType.Topic)
+          _        <- bindQueue(q, x, rk)
+          consumer <- createAutoAckConsumer[String](q)
           message  <- consumer
         } yield message
       }
 
-    val producer: Stream[IO, Unit] =
+    def producer(q: QueueName, x: ExchangeName, rk: RoutingKey): Stream[IO, Unit] =
       createConnectionChannel flatMap { implicit channel =>
         for {
-          _         <- declareQueue(DeclarationQueueConfig.default(queueName))
-          _         <- declareExchange(exchangeName, ExchangeType.Topic)
-          _         <- bindQueue(queueName, exchangeName, routingKey)
-          publisher <- createPublisher[String](exchangeName, routingKey)
+          _         <- declareQueue(DeclarationQueueConfig.default(q))
+          _         <- declareExchange(x, ExchangeType.Topic)
+          _         <- bindQueue(q, x, rk)
+          publisher <- createPublisher[String](x, rk)
           _         <- Stream.eval(publisher(message))
         } yield ()
       }
 
     for {
-      _               <- producer
-      receivedMessage <- consumer.take(1)
+      (q, x, rk)      <- Stream.eval(randomQueueData)
+      _               <- producer(q, x, rk)
+      receivedMessage <- consumer(q, x, rk).take(1)
     } yield {
-      receivedMessage shouldBe expectedDelivery(receivedMessage.deliveryTag, exchangeName, routingKey, message)
+      receivedMessage shouldBe expectedDelivery(receivedMessage.deliveryTag, x, rk, message)
     }
   }
 
   private def withRabbit[A](fa: Fs2Rabbit[IO] => Stream[IO, A]): Unit = IOAssertion {
-    Fs2Rabbit[IO](rabbitConfig).flatMap(r => fa(r).compile.drain)
+    Fs2Rabbit[IO](config).flatMap(r => fa(r).compile.drain)
   }
 
   private def withNackRabbit[A](fa: Fs2Rabbit[IO] => Stream[IO, A]): Unit = IOAssertion {
-    Fs2Rabbit[IO](rabbitConfig.copy(requeueOnNack = true)).flatMap(r => fa(r).compile.drain)
+    Fs2Rabbit[IO](config.copy(requeueOnNack = true)).flatMap(r => fa(r).compile.drain)
   }
 
-  private def randomQueueData(): (QueueName, ExchangeName, RoutingKey) = {
-    val queueName    = QueueName(randomString())
-    val exchangeName = ExchangeName(randomString())
-    val routingKey   = RoutingKey(randomString())
+  private def randomQueueData: IO[(QueueName, ExchangeName, RoutingKey)] =
+    (mkRandomString, mkRandomString, mkRandomString).mapN {
+      case (a, b, c) =>
+        (QueueName(a), ExchangeName(b), RoutingKey(c))
+    }
 
-    (queueName, exchangeName, routingKey)
-  }
-
-  private def randomString(): String = Random.alphanumeric.take(6).mkString.toLowerCase
+  private def mkRandomString: IO[String] = IO(Random.alphanumeric.take(6).mkString.toLowerCase)
 
   private def expectedDelivery(tag: DeliveryTag, exchangeName: ExchangeName, routingKey: RoutingKey, payload: String) =
     AmqpEnvelope(
@@ -597,7 +565,7 @@ class Fs2RabbitSpec extends FlatSpec with Matchers with DockerRabbit with Either
     )
 
   private def takeWithTimeOut[A](stream: Stream[IO, A], timeout: FiniteDuration): Stream[IO, Option[A]] =
-    stream.last.mergeHaltR(Stream.sleep[IO](timeout).map(_ => None))
+    stream.last.mergeHaltR(Stream.sleep[IO](timeout).as(None))
 
   private def listener(promise: Deferred[IO, PublishReturn]): PublishReturn => IO[Unit] = promise.complete
 

--- a/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/RabbitSuite.scala
+++ b/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/RabbitSuite.scala
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2rabbit
+package com.github.gvolpe.fs2rabbit.interpreter
 
-import cats.effect.IO
-import cats.syntax.functor._
+import cats.effect.{ContextShift, IO}
+import com.github.gvolpe.fs2rabbit.{BaseSpec, DockerRabbit}
+import com.github.gvolpe.fs2rabbit.config.Fs2RabbitConfig
 
-object IOAssertion {
-  def apply[A](ioa: IO[A]): Unit = ioa.void.unsafeRunSync()
+import scala.concurrent.ExecutionContext
+
+class RabbitSuite extends BaseSpec with DockerRabbit with Fs2RabbitSpec with ConnectionStreamSpec {
+  override implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  override val config: Fs2RabbitConfig       = rabbitConfig
 }

--- a/tests/src/test/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStreamSpec.scala
+++ b/tests/src/test/scala/com/github/gvolpe/fs2rabbit/resiliency/ResilientStreamSpec.scala
@@ -16,27 +16,17 @@
 
 package com.github.gvolpe.fs2rabbit.resiliency
 
-import cats.effect.{IO, Timer}
+import cats.effect.IO
 import cats.effect.concurrent.Ref
 import cats.syntax.apply._
-import com.github.gvolpe.fs2rabbit.IOAssertion
-import com.github.gvolpe.fs2rabbit.effects.Log
+import com.github.gvolpe.fs2rabbit.{BaseSpec, IOAssertion}
 import fs2._
-import org.scalatest.{FlatSpecLike, Matchers}
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-class ResilientStreamSpec extends FlatSpecLike with Matchers {
+class ResilientStreamSpec extends BaseSpec {
 
-  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
-
-  private val sink: Pipe[IO, Int, Unit] = _.evalMap(n => IO(println(n)))
-
-  implicit val logger: Log[IO] = new Log[IO] {
-    override def info(value: String): IO[Unit]     = IO(println(value))
-    override def error(error: Throwable): IO[Unit] = IO(println(error.getMessage))
-  }
+  private val sink: Pipe[IO, Int, Unit] = _.evalMap(putStrLn)
 
   it should "run a stream until it's finished" in IOAssertion {
     val program = Stream(1, 2, 3).covary[IO].through(sink)


### PR DESCRIPTION
Previously, a `docker` instance was being started per single test. I just created a suite so we only spin up a single instance to run tests faster.

There were also some side-effectful methods in tests (`randomQueueData()` and `randomString()`) that I don't know when they made it into master but I just refactored them.

@iRevive wanna have a look?