### PR TITLE
Support of RPC pattern

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/AMQPClient.scala
@@ -51,6 +51,7 @@ trait Declaration[F[_]] {
   def declareExchange(channel: Channel, exchangeConfig: DeclarationExchangeConfig): F[Unit]
   def declareExchangeNoWait(value: Channel, exchangeConfig: DeclarationExchangeConfig): F[Unit]
   def declareExchangePassive(channel: Channel, exchangeName: ExchangeName): F[Unit]
+  def declareQueue(channel: Channel): F[QueueName]
   def declareQueue(channel: Channel, queueConfig: DeclarationQueueConfig): F[Unit]
   def declareQueueNoWait(channel: Channel, queueConfig: DeclarationQueueConfig): F[Unit]
   def declareQueuePassive(channel: Channel, queueName: QueueName): F[Unit]

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/AMQPClientStream.scala
@@ -294,6 +294,10 @@ class AMQPClientStream[F[_]: Effect](implicit SE: StreamEval[F]) extends AMQPCli
     channel.exchangeDeclarePassive(exchangeName.value)
   }
 
+  override def declareQueue(channel: Channel): Stream[F, QueueName] = SE.evalF {
+    QueueName(channel.queueDeclare().getQueue)
+  }
+
   override def declareQueue(
       channel: Channel,
       config: DeclarationQueueConfig

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -168,6 +168,9 @@ class Fs2Rabbit[F[_]: Concurrent] private[fs2rabbit] (
   def declareExchangePassive(exchangeName: ExchangeName)(implicit channel: AMQPChannel): Stream[F, Unit] =
     amqpClient.declareExchangePassive(channel.value, exchangeName)
 
+  def declareQueue(implicit channel: AMQPChannel): Stream[F, QueueName] =
+    amqpClient.declareQueue(channel.value)
+
   def declareQueue(queueConfig: DeclarationQueueConfig)(implicit channel: AMQPChannel): Stream[F, Unit] =
     amqpClient.declareQueue(channel.value, queueConfig)
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
@@ -112,6 +112,8 @@ object model {
       userId: Option[String] = None,
       appId: Option[String] = None,
       expiration: Option[String] = None,
+      replyTo: Option[String] = None,
+      clusterId: Option[String] = None,
       headers: Map[String, AmqpHeaderVal] = Map.empty
   )
 
@@ -130,6 +132,8 @@ object model {
         userId = Option(basicProps.getUserId),
         appId = Option(basicProps.getAppId),
         expiration = Option(basicProps.getExpiration),
+        replyTo = Option(basicProps.getReplyTo),
+        clusterId = Option(basicProps.getClusterId),
         headers = Option(basicProps.getHeaders)
           .fold(Map.empty[String, Object])(_.asScala.toMap)
           .map {
@@ -150,6 +154,8 @@ object model {
           .appId(props.appId.orNull)
           .userId(props.userId.orNull)
           .expiration(props.expiration.orNull)
+          .replyTo(props.replyTo.orNull)
+          .clusterId(props.clusterId.orNull)
           .headers(props.headers.mapValues[AnyRef](_.impure).asJava)
           .build()
     }

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/AmqpPropertiesSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/AmqpPropertiesSpec.scala
@@ -36,18 +36,18 @@ class AmqpPropertiesSpec extends FlatSpecLike with Matchers with AmqpPropertiesA
   it should "create an empty amqp properties" in {
     AmqpProperties.empty should be(
       AmqpProperties(None,
-                 None,
-                 None,
-                 None,
-                 None,
-                 None,
-                 None,
-                 None,
-                 None,
-                 None,
-                 None,
-                 None,
-                 Map.empty[String, AmqpHeaderVal]))
+                     None,
+                     None,
+                     None,
+                     None,
+                     None,
+                     None,
+                     None,
+                     None,
+                     None,
+                     None,
+                     None,
+                     Map.empty[String, AmqpHeaderVal]))
   }
 
   it should "handle null values in Java AMQP.BasicProperties" in {
@@ -96,19 +96,21 @@ trait AmqpPropertiesArbitraries extends PropertyChecks {
       clusterId       <- Gen.option(Gen.alphaNumStr)
       headers         <- Gen.mapOf[String, AmqpHeaderVal](headersGen)
     } yield
-      AmqpProperties(contentType,
-                     contentEncoding,
-                     priority,
-                     deliveryMode.map(DeliveryMode.from),
-                     correlationId,
-                     messageId,
-                     messageType,
-                     userId,
-                     appId,
-                     expiration,
-                     replyTo,
-                     clusterId,
-                     headers)
+      AmqpProperties(
+        contentType,
+        contentEncoding,
+        priority,
+        deliveryMode.map(DeliveryMode.from),
+        correlationId,
+        messageId,
+        messageType,
+        userId,
+        appId,
+        expiration,
+        replyTo,
+        clusterId,
+        headers
+      )
   }
 
 }

--- a/core/src/test/scala/com/github/gvolpe/fs2rabbit/AmqpPropertiesSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/fs2rabbit/AmqpPropertiesSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.prop.PropertyChecks
 
 class AmqpPropertiesSpec extends FlatSpecLike with Matchers with AmqpPropertiesArbitraries {
 
-  forAll { (amqpProperties: AmqpProperties) =>
+  forAll { amqpProperties: AmqpProperties =>
     it should s"convert from and to Java AMQP.BasicProperties for $amqpProperties" in {
       val basicProps = amqpProperties.asBasicProps
       AmqpProperties.from(basicProps) should be(amqpProperties)
@@ -35,7 +35,19 @@ class AmqpPropertiesSpec extends FlatSpecLike with Matchers with AmqpPropertiesA
 
   it should "create an empty amqp properties" in {
     AmqpProperties.empty should be(
-      AmqpProperties(None, None, None, None, None, None, None, None, None, None, Map.empty[String, AmqpHeaderVal]))
+      AmqpProperties(None,
+                 None,
+                 None,
+                 None,
+                 None,
+                 None,
+                 None,
+                 None,
+                 None,
+                 None,
+                 None,
+                 None,
+                 Map.empty[String, AmqpHeaderVal]))
   }
 
   it should "handle null values in Java AMQP.BasicProperties" in {
@@ -80,6 +92,8 @@ trait AmqpPropertiesArbitraries extends PropertyChecks {
       userId          <- Gen.option(Gen.alphaNumStr)
       appId           <- Gen.option(Gen.alphaNumStr)
       expiration      <- Gen.option(Gen.alphaNumStr)
+      replyTo         <- Gen.option(Gen.alphaNumStr)
+      clusterId       <- Gen.option(Gen.alphaNumStr)
       headers         <- Gen.mapOf[String, AmqpHeaderVal](headersGen)
     } yield
       AmqpProperties(contentType,
@@ -92,6 +106,8 @@ trait AmqpPropertiesArbitraries extends PropertyChecks {
                      userId,
                      appId,
                      expiration,
+                     replyTo,
+                     clusterId,
                      headers)
   }
 

--- a/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/RPCDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2rabbit/examples/RPCDemo.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017-2019 Gabriel Volpe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.fs2rabbit.examples
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.UUID
+
+import cats.data.{Kleisli, NonEmptyList}
+import cats.effect._
+import cats.syntax.applicative._
+import cats.syntax.functor._
+import com.github.gvolpe.fs2rabbit.config.declaration.DeclarationQueueConfig
+import com.github.gvolpe.fs2rabbit.config.{Fs2RabbitConfig, Fs2RabbitNodeConfig}
+import com.github.gvolpe.fs2rabbit.effects.MessageEncoder
+import com.github.gvolpe.fs2rabbit.interpreter.Fs2Rabbit
+import com.github.gvolpe.fs2rabbit.model._
+import fs2.Stream
+
+object RPCDemo extends IOApp {
+
+  private val config: Fs2RabbitConfig = Fs2RabbitConfig(
+    virtualHost = "/",
+    nodes = NonEmptyList.one(
+      Fs2RabbitNodeConfig(
+        host = "127.0.0.1",
+        port = 5672
+      )
+    ),
+    username = Some("guest"),
+    password = Some("guest"),
+    ssl = false,
+    connectionTimeout = 3,
+    requeueOnNack = false,
+    internalQueueSize = Some(500),
+    automaticRecovery = true
+  )
+
+  override def run(args: List[String]): IO[ExitCode] =
+    Fs2Rabbit[IO](config).flatMap { implicit fs2Rabbit =>
+      val queue = QueueName("rpc_queue")
+      runServer[IO](queue).concurrently(runClient[IO](queue)).compile.drain.as(ExitCode.Success)
+    }
+
+  def runServer[F[_]: Sync](rpcQueue: QueueName)(implicit R: Fs2Rabbit[F]): Stream[F, Unit] =
+    R.createConnectionChannel.flatMap { implicit channel =>
+      new RPCServer[F](rpcQueue).serve
+    }
+
+  def runClient[F[_]: Concurrent](rpcQueue: QueueName)(implicit R: Fs2Rabbit[F]): Stream[F, Unit] =
+    R.createConnectionChannel.flatMap { implicit channel =>
+      val client = new RPCClient[F](rpcQueue)
+
+      Stream(
+        client.call("Message 1"),
+        client.call("Message 2"),
+        client.call("Message 3")
+      ).parJoinUnbounded.void
+    }
+
+}
+
+class RPCClient[F[_]: Sync](rpcQueue: QueueName)(implicit R: Fs2Rabbit[F], channel: AMQPChannel) {
+
+  private val EmptyExchange = ExchangeName("")
+
+  implicit val encoder: MessageEncoder[F, AmqpMessage[String]] =
+    Kleisli[F, AmqpMessage[String], AmqpMessage[Array[Byte]]](s => s.copy(payload = s.payload.getBytes(UTF_8)).pure[F])
+
+  def call(body: String): Stream[F, AmqpEnvelope[String]] = {
+    val correlationId = UUID.randomUUID().toString
+
+    for {
+      queue     <- R.declareQueue
+      publisher <- R.createPublisher[AmqpMessage[String]](EmptyExchange, RoutingKey(rpcQueue.value))
+      _         <- Stream.eval(putStrLn(s"[Client] Message $body. ReplyTo queue $queue. Correlation $correlationId"))
+      message   = AmqpMessage(body, AmqpProperties(replyTo = Some(queue.value), correlationId = Some(correlationId)))
+      _         <- Stream.eval(publisher(message))
+      consumer  <- R.createAutoAckConsumer(queue)
+      response  <- consumer.filter(_.properties.correlationId.contains(correlationId)).take(1)
+      _         <- Stream.eval(putStrLn(s"[Client] Request $body. Received response [${response.payload}]"))
+    } yield response
+  }
+
+}
+
+class RPCServer[F[_]: Sync](rpcQueue: QueueName)(implicit R: Fs2Rabbit[F], channel: AMQPChannel) {
+
+  private val EmptyExchange = ExchangeName("")
+
+  private implicit val encoder: MessageEncoder[F, AmqpMessage[String]] =
+    Kleisli[F, AmqpMessage[String], AmqpMessage[Array[Byte]]](s => s.copy(payload = s.payload.getBytes(UTF_8)).pure[F])
+
+  def serve: Stream[F, Unit] =
+    for {
+      _        <- R.declareQueue(DeclarationQueueConfig.default(rpcQueue))
+      consumer <- R.createAutoAckConsumer(rpcQueue)
+      _        <- consumer.flatMap(handler)
+    } yield ()
+
+  private def handler(e: AmqpEnvelope[String]): Stream[F, Unit] = {
+    val correlationId = e.properties.correlationId
+    val replyTo       = e.properties.replyTo.toRight(new IllegalArgumentException("ReplyTo parameter is missing"))
+
+    for {
+      rk        <- Stream.fromEither[F](replyTo)
+      _         <- Stream.eval(putStrLn(s"[Server] Received message [${e.payload}]. ReplyTo $rk. CorrelationId $correlationId"))
+      publisher <- R.createPublisher[AmqpMessage[String]](EmptyExchange, RoutingKey(rk))
+      response  = AmqpMessage(s"Response for ${e.payload}", AmqpProperties(correlationId = correlationId))
+      _         <- Stream.eval(publisher(response))
+    } yield ()
+
+  }
+
+}

--- a/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -47,6 +47,18 @@ trait Fs2RabbitSpec { self: BaseSpec =>
     }
   }
 
+  it should "create a connection and a random queue" in withRabbit { interpreter =>
+    import interpreter._
+
+    createConnectionChannel.flatMap { implicit channel =>
+      for {
+        q         <- declareQueue
+      } yield {
+        q.value should not be empty
+      }
+    }
+  }
+
   it should "create a connection and a queue with options enabled" in withRabbit { interpreter =>
     import interpreter._
 

--- a/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/tests/src/test/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -52,7 +52,7 @@ trait Fs2RabbitSpec { self: BaseSpec =>
 
     createConnectionChannel.flatMap { implicit channel =>
       for {
-        q         <- declareQueue
+        q <- declareQueue
       } yield {
         q.value should not be empty
       }


### PR DESCRIPTION
Hi @gvolpe. 

I added a new method `declareQueue` which doesn't take arguments. It creates a queue with a random name. This functionality is necessary for RPC pattern.

This PR should cover https://github.com/gvolpe/fs2-rabbit/issues/114.