### PR TITLE
Allow multiple channels to be created for a single connection

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Channeller.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Channeller.scala
@@ -18,7 +18,6 @@ package com.github.gvolpe.fs2rabbit.algebra
 
 import com.github.gvolpe.fs2rabbit.model.AMQPChannel
 
-// TODO: Find a better name - I've called it this to avoid clash with the rabbit class called Channel
 trait Channeller[F[_]] {
   def createChannel: F[AMQPChannel]
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Channeller.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Channeller.scala
@@ -16,10 +16,9 @@
 
 package com.github.gvolpe.fs2rabbit.algebra
 
-import com.github.gvolpe.fs2rabbit.model.{AMQPChannel, AMQPConnection}
+import com.github.gvolpe.fs2rabbit.model.AMQPChannel
 
-trait Connection[F[_]] {
-  def createConnection: F[AMQPConnection]
-
-  def createConnectionChannel: F[AMQPChannel]
+// TODO: Find a better name - I've called it this to avoid clash with the rabbit class called Channel
+trait Channeller[F[_]] {
+  def createChannel: F[AMQPChannel]
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ChannelStream.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/ChannelStream.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 Gabriel Volpe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.fs2rabbit.interpreter
+
+import cats.effect.Sync
+import cats.syntax.apply._
+import cats.syntax.functor._
+import com.github.gvolpe.fs2rabbit.algebra.Channeller
+import com.github.gvolpe.fs2rabbit.effects.Log
+import com.github.gvolpe.fs2rabbit.model
+import com.github.gvolpe.fs2rabbit.model.{AMQPChannel, AMQPConnection, RabbitChannel}
+import fs2.Stream
+
+class ChannelStream[F[_]](
+    connection: AMQPConnection
+)(implicit F: Sync[F], L: Log[F])
+    extends Channeller[Stream[F, ?]] {
+
+  private val acquireChannel: F[AMQPChannel] =
+    for {
+      chan <- F.delay(connection.value.createChannel())
+    } yield RabbitChannel(chan)
+
+  override def createChannel: Stream[F, model.AMQPChannel] =
+    Stream
+      .bracket(acquireChannel) {
+        case RabbitChannel(chan) =>
+          L.info(s"Releasing channel: $chan previously acquired.") *>
+            F.delay { if (chan.isOpen) chan.close() }
+      }
+}

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/interpreter/Fs2Rabbit.scala
@@ -16,7 +16,6 @@
 
 package com.github.gvolpe.fs2rabbit.interpreter
 
-import javax.net.ssl.SSLContext
 import cats.effect.{Concurrent, ConcurrentEffect}
 import cats.syntax.functor._
 import com.github.gvolpe.fs2rabbit.algebra._
@@ -27,6 +26,7 @@ import com.github.gvolpe.fs2rabbit.effects.{EnvelopeDecoder, MessageEncoder}
 import com.github.gvolpe.fs2rabbit.model._
 import com.github.gvolpe.fs2rabbit.program._
 import fs2.Stream
+import javax.net.ssl.SSLContext
 
 // $COVERAGE-OFF$
 object Fs2Rabbit {
@@ -59,6 +59,8 @@ class Fs2Rabbit[F[_]: Concurrent] private[fs2rabbit] (
 
   private[fs2rabbit] val publishingProgram: Publishing[Stream[F, ?], F] =
     new PublishingProgram[F](amqpClient)
+
+  def createConnection: Stream[F, AMQPConnection] = connectionStream.createConnection
 
   def createConnectionChannel: Stream[F, AMQPChannel] = connectionStream.createConnectionChannel
 

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/model.scala
@@ -26,7 +26,7 @@ import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.effects.{EnvelopeDecoder, MessageEncoder}
 import com.github.gvolpe.fs2rabbit.model.AmqpHeaderVal._
 import com.rabbitmq.client.impl.LongStringHelper
-import com.rabbitmq.client.{AMQP, Channel, LongString}
+import com.rabbitmq.client.{AMQP, Channel, Connection, LongString}
 import fs2.Stream
 
 import scala.collection.JavaConverters._
@@ -39,6 +39,11 @@ object model {
     def value: Channel
   }
   case class RabbitChannel(value: Channel) extends AMQPChannel
+
+  trait AMQPConnection {
+    def value: Connection
+  }
+  case class RabbitConnection(value: Connection) extends AMQPConnection
 
   case class ExchangeName(value: String) extends AnyVal
   case class QueueName(value: String)    extends AnyVal

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-version in ThisBuild := "1.2.0"
+version in ThisBuild := "1.2.1-SNAPSHOT"
 


### PR DESCRIPTION
[https://github.com/gvolpe/fs2-rabbit/issues/186]

The aim here is to allow a client to create a connection out of a ConnectionStream and then use that to create multiple channels that different parts of the system can use. This supports the model recommended for rabbitmq where different threads operate on separate channels.

* Added a `createConnection` method to the `Connection[F[_]]` trait alongside the existing `createConnectionChannel`
* Created a `Channeller` trait (named to avoid clash with rabbit `Channel` class, up for a better name) with a `createChannel` method
* Created a `ChannelStream` implementation that will create a stream of channels out of a provided connection
* Created an `AMQPConnection` model to wrap a rabbit connection, in line with the `AMQPChannel` model
* Bumped version to 1.2.1-SNAPSHOT for the moment